### PR TITLE
Log error message when failing to save player data

### DIFF
--- a/internal/v1_17_R1/src/main/java/com/lishid/openinv/internal/v1_17_R1/OpenPlayer.java
+++ b/internal/v1_17_R1/src/main/java/com/lishid/openinv/internal/v1_17_R1/OpenPlayer.java
@@ -67,7 +67,7 @@ public class OpenPlayer extends CraftPlayer {
             File file2 = new File(worldNBTStorage.getPlayerDir(), player.getStringUUID() + ".dat_old");
             Util.safeReplaceFile(file1, file, file2);
         } catch (Exception e) {
-            LogManager.getLogger().warn("Failed to save player data for {}", player.getName().getString());
+            LogManager.getLogger().warn("Failed to save player data for {}: {}", player.getName().getString(), e.getMessage());
         }
     }
 

--- a/internal/v1_18_R1/src/main/java/com/lishid/openinv/internal/v1_18_R1/OpenPlayer.java
+++ b/internal/v1_18_R1/src/main/java/com/lishid/openinv/internal/v1_18_R1/OpenPlayer.java
@@ -67,7 +67,7 @@ public class OpenPlayer extends CraftPlayer {
             File file2 = new File(worldNBTStorage.getPlayerDir(), player.getStringUUID() + ".dat_old");
             Util.safeReplaceFile(file1, file, file2);
         } catch (Exception e) {
-            LogManager.getLogger().warn("Failed to save player data for {}", player.getName().getString());
+            LogManager.getLogger().warn("Failed to save player data for {}: {}", player.getName().getString(), e.getMessage());
         }
     }
 

--- a/internal/v1_18_R2/src/main/java/com/lishid/openinv/internal/v1_18_R2/OpenPlayer.java
+++ b/internal/v1_18_R2/src/main/java/com/lishid/openinv/internal/v1_18_R2/OpenPlayer.java
@@ -67,7 +67,7 @@ public class OpenPlayer extends CraftPlayer {
             File file2 = new File(worldNBTStorage.getPlayerDir(), player.getStringUUID() + ".dat_old");
             Util.safeReplaceFile(file1, file, file2);
         } catch (Exception e) {
-            LogManager.getLogger().warn("Failed to save player data for {}", player.getName().getString());
+            LogManager.getLogger().warn("Failed to save player data for {}: {}", player.getName().getString(), e.getMessage());
         }
     }
 


### PR DESCRIPTION
This adds the error message of the exception to the log message if the plugin fails to save the player data to better be able to figure out why this happens.