### PR TITLE
Update dependencies, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,23 @@ jobs:
           name: api
           path: ./api/target/openinvapi*.jar
 
+  merge-dependabot:
+    name: Auto-merge Dependabot PRs
+    needs: [ build ]
+    if: github.event.name == 'pull_request_target' && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: approve
+        uses: hmarr/auto-approve-action@v2.0.0
+          with:
+            github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: merge
+        uses: "pascalgn/automerge-action@v0.15.2"
+          env:
+            GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+            MERGE_LABELS: "dependencies"
+            MERGE_METHOD: "squash"
+
   release:
     name: Create Github Release
     needs: [ build ]
@@ -66,7 +83,7 @@ jobs:
 
       - name: Create Release
         id: create-release
-        uses: softprops/action-gh-release@v0.1.5
+        uses: softprops/action-gh-release@v0.1.14
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,25 +8,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Set Up Java
-        uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
           java-version: '17'
+          cache: 'maven'
 
-      # Use cache to speed up build
-      - name: Cache Maven Repo
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-
-      # Install Spigot dependencies.
-      # This script uses Maven to check all required installations and ensure that they are present.
+      # Install Spigot dependencies if necessary.
       - name: Install Spigot Dependencies
         run: . scripts/install_spigot_dependencies.sh
 
@@ -36,13 +26,13 @@ jobs:
       # Upload artifacts
       - name: Upload Distributable Jar
         id: upload-final
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: ./target/OpenInv.jar
       - name: Upload API Jar
         id: upload-api
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: api
           path: ./api/target/openinvapi*.jar
@@ -53,12 +43,24 @@ jobs:
     if: github.event.name == 'pull_request_target' && github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: approve
+      - uses: actions/checkout@v3
+      # Filter dependency changes based on path.
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            maven:
+              - '**/pom.xml'
+
+      # Only auto-merge Maven changes.
+      - if: steps.changes.outputs.maven == 'true'
+        name: Approve
         uses: hmarr/auto-approve-action@v2.0.0
           with:
             github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: merge
-        uses: "pascalgn/automerge-action@v0.15.2"
+      - if: steps.changes.outputs.maven == 'true'
+        name: Merge
+        uses: pascalgn/automerge-action@v0.15.2
           env:
             GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
             MERGE_LABELS: "dependencies"
@@ -70,16 +72,19 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
+      # Fetch all history - used to assemble changelog.
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set Release Variables
         run: bash ./scripts/set_release_env.sh
 
-      - name: Download Artifacts
-        uses: actions/download-artifact@v2
+      - name: Download Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
 
       - name: Create Release
         id: create-release

--- a/internal/v1_17_R1/pom.xml
+++ b/internal/v1_17_R1/pom.xml
@@ -44,10 +44,6 @@
       <classifier>remapped-mojang</classifier>
     </dependency>
     <dependency>
-      <artifactId>openinvapi</artifactId>
-      <groupId>com.lishid</groupId>
-    </dependency>
-    <dependency>
       <artifactId>openinvplugincore</artifactId>
       <groupId>com.lishid</groupId>
     </dependency>
@@ -61,7 +57,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <!-- Cannot use minimizeJar until maven-shade-plugin 3.3.0 releases; ASM used does not support Java 16. -->
+        <!-- Cannot use minimizeJar: MSHADE-366 -->
         <configuration>
           <minimizeJar>false</minimizeJar>
         </configuration>

--- a/internal/v1_18_R1/pom.xml
+++ b/internal/v1_18_R1/pom.xml
@@ -49,10 +49,6 @@
       <classifier>remapped-mojang</classifier>
     </dependency>
     <dependency>
-      <artifactId>openinvapi</artifactId>
-      <groupId>com.lishid</groupId>
-    </dependency>
-    <dependency>
       <artifactId>openinvplugincore</artifactId>
       <groupId>com.lishid</groupId>
     </dependency>
@@ -66,7 +62,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <!-- Cannot use minimizeJar until maven-shade-plugin 3.3.0 releases; ASM used does not support Java 17. -->
+        <!-- Cannot use minimizeJar: MSHADE-366 -->
         <configuration>
           <minimizeJar>false</minimizeJar>
         </configuration>

--- a/internal/v1_18_R2/pom.xml
+++ b/internal/v1_18_R2/pom.xml
@@ -49,10 +49,6 @@
       <classifier>remapped-mojang</classifier>
     </dependency>
     <dependency>
-      <artifactId>openinvapi</artifactId>
-      <groupId>com.lishid</groupId>
-    </dependency>
-    <dependency>
       <artifactId>openinvplugincore</artifactId>
       <groupId>com.lishid</groupId>
     </dependency>
@@ -66,7 +62,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
-        <!-- Cannot use minimizeJar until maven-shade-plugin 3.3.0 releases; ASM used does not support Java 17. -->
+        <!-- Cannot use minimizeJar: MSHADE-366 -->
         <configuration>
           <minimizeJar>false</minimizeJar>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>16</maven.compiler.source>
+    <maven.compiler.target>16</maven.compiler.target>
     <!-- Silence IDE warning - property is declared in individual internal modules. -->
     <spigot.version>unknown</spigot.version>
   </properties>
@@ -72,13 +72,13 @@
         <artifactId>annotations</artifactId>
         <groupId>org.jetbrains</groupId>
         <scope>provided</scope>
-        <version>21.0.1</version>
+        <version>23.0.0</version>
       </dependency>
       <dependency>
         <artifactId>spigot-api</artifactId>
         <groupId>org.spigotmc</groupId>
         <scope>provided</scope>
-        <version>1.16.5-R0.1-SNAPSHOT</version>
+        <version>1.17.1-R0.1-SNAPSHOT</version>
       </dependency>
       <dependency>
         <artifactId>openinvapi</artifactId>
@@ -146,7 +146,7 @@
         <plugin>
           <groupId>net.md-5</groupId>
           <artifactId>specialsource-maven-plugin</artifactId>
-          <version>1.2.2</version>
+          <version>1.2.4</version>
           <executions>
             <execution>
               <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,12 @@
         <groupId>com.lishid</groupId>
         <scope>compile</scope>
         <version>4.1.11-SNAPSHOT</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.lishid</groupId>
+            <artifactId>openinvapi</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -128,7 +134,7 @@
             </execution>
           </executions>
           <groupId>org.apache.maven.plugins</groupId>
-          <version>3.2.4</version>
+          <version>3.3.0</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
* Update dependencies
* Clean up shade-related warnings during compilation
* Remove now-redundant cache action
* Add Dependabot
  * Configured for both Maven and Actions
  * Maven updates will auto-merge if they compile