### PR TITLE
Update to 1.19.1

### DIFF
--- a/internal/v1_19_R1/pom.xml
+++ b/internal/v1_19_R1/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <spigot.version>1.19-R0.1-SNAPSHOT</spigot.version>
+    <spigot.version>1.19.1-R0.1-SNAPSHOT</spigot.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
v1_19_R1 is now 1.19.1, this will break 1.19 support.

Sorry about the previous PR, you can see the build working with spigot 1.19.1 on my fork [here](https://github.com/Elioby/OpenInv/runs/7593084853?check_suite_focus=true).