### PR TITLE
Fix cache never being used for Spigot dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,16 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <!--
+            ~ This plugin is used in scripts to determine if NMS dependencies need to be installed. This must be
+            ~ declared so that we don't run into MDEP-204; the default SuperPOM declares version 2.8.0.
+            -->
+          <artifactId>maven-dependency-plugin</artifactId>
+          <groupId>org.apache.maven.plugins</groupId>
+          <version>3.3.0</version>
+        </plugin>
+
+        <plugin>
           <artifactId>maven-shade-plugin</artifactId>
           <configuration>
             <filters>

--- a/scripts/install_spigot_dependencies.sh
+++ b/scripts/install_spigot_dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2011-2021 lishid. All rights reserved.
+# Copyright (C) 2011-2022 lishid. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -34,9 +34,7 @@ readarray -t versions <<< "$(. ./scripts/get_spigot_versions.sh)"
 echo Found Spigot dependencies: "${versions[@]}"
 
 # Install dependencies aside from Spigot prior to running in offline mode.
-# Note that the default SuperPOM declares maven-dependency-plugin 2.8.0.
-# Unfortunately, we run into MDEP-204 and require a version >= 3.1.2.
-mvn org.apache.maven.plugins:maven-dependency-plugin:3.2.0:go-offline -DexcludeArtifactIds=spigot
+mvn dependency:go-offline -DexcludeArtifactIds=spigot
 
 for version in "${versions[@]}"; do
   set -e


### PR DESCRIPTION
Because the maven-dependency-plugin in the SuperPOM is 2.8.0, it needed to be specified in the `dependency:get` call as well so that the version used is actually installed locally during `dependency:go-offline`. Including it in the pom allows us to ensure consistent versioning and enables updating it via dependabot.