### PR TITLE
Improve language manager

### DIFF
--- a/plugin/src/main/java/com/lishid/openinv/OpenInv.java
+++ b/plugin/src/main/java/com/lishid/openinv/OpenInv.java
@@ -26,8 +26,9 @@ import com.lishid.openinv.internal.ISpecialEnderChest;
 import com.lishid.openinv.internal.ISpecialInventory;
 import com.lishid.openinv.internal.ISpecialPlayerInventory;
 import com.lishid.openinv.util.ConfigUpdater;
-import com.lishid.openinv.util.LanguageManager;
+import com.lishid.openinv.util.lang.LanguageManager;
 import com.lishid.openinv.util.Permissions;
+import com.lishid.openinv.util.lang.Replacement;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Objects;
@@ -362,7 +363,7 @@ public class OpenInv extends JavaPlugin implements IOpenInv {
     public @Nullable String getLocalizedMessage(
             @NotNull CommandSender sender,
             @NotNull String key,
-            String @NotNull ... replacements) {
+            Replacement @NotNull ... replacements) {
         return this.languageManager.getValue(key, getLocale(sender), replacements);
     }
 
@@ -382,7 +383,7 @@ public class OpenInv extends JavaPlugin implements IOpenInv {
         }
     }
 
-    public void sendMessage(@NotNull CommandSender sender, @NotNull String key, String @NotNull... replacements) {
+    public void sendMessage(@NotNull CommandSender sender, @NotNull String key, Replacement @NotNull... replacements) {
         String message = getLocalizedMessage(sender, key, replacements);
 
         if (message != null && !message.isEmpty()) {

--- a/plugin/src/main/java/com/lishid/openinv/commands/ContainerSettingCommand.java
+++ b/plugin/src/main/java/com/lishid/openinv/commands/ContainerSettingCommand.java
@@ -18,6 +18,7 @@ package com.lishid.openinv.commands;
 
 import com.lishid.openinv.OpenInv;
 import com.lishid.openinv.util.TabCompleter;
+import com.lishid.openinv.util.lang.Replacement;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -69,7 +70,11 @@ public class ContainerSettingCommand implements TabExecutor {
             onOff = String.valueOf(getSetting.test(player));
         }
 
-        plugin.sendMessage(sender, "messages.info.settingState","%setting%", any ? "AnyContainer" : "SilentContainer", "%state%", onOff);
+        plugin.sendMessage(
+                sender,
+                "messages.info.settingState",
+                new Replacement("%setting%", any ? "AnyContainer" : "SilentContainer"),
+                new Replacement("%state%", onOff));
 
         return true;
     }

--- a/plugin/src/main/java/com/lishid/openinv/commands/OpenInvCommand.java
+++ b/plugin/src/main/java/com/lishid/openinv/commands/OpenInvCommand.java
@@ -20,6 +20,7 @@ import com.lishid.openinv.OpenInv;
 import com.lishid.openinv.internal.ISpecialInventory;
 import com.lishid.openinv.util.Permissions;
 import com.lishid.openinv.util.TabCompleter;
+import com.lishid.openinv.util.lang.Replacement;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -171,16 +172,20 @@ public class OpenInvCommand implements TabExecutor {
             // Protected check
             if (!Permissions.OVERRIDE.hasPermission(player)
                     && Permissions.EXEMPT.hasPermission(onlineTarget)) {
-                plugin.sendMessage(player, "messages.error.permissionExempt",
-                        "%target%", onlineTarget.getDisplayName());
+                plugin.sendMessage(
+                        player,
+                        "messages.error.permissionExempt",
+                        new Replacement("%target%", onlineTarget.getDisplayName()));
                 return;
             }
 
             // Crossworld check
             if (!Permissions.CROSSWORLD.hasPermission(player)
                     && !onlineTarget.getWorld().equals(player.getWorld())) {
-                plugin.sendMessage(player, "messages.error.permissionCrossWorld",
-                        "%target%", onlineTarget.getDisplayName());
+                plugin.sendMessage(
+                        player,
+                        "messages.error.permissionCrossWorld",
+                        new Replacement("%target%", onlineTarget.getDisplayName()));
                 return;
             }
         }

--- a/plugin/src/main/java/com/lishid/openinv/commands/SearchContainerCommand.java
+++ b/plugin/src/main/java/com/lishid/openinv/commands/SearchContainerCommand.java
@@ -18,6 +18,7 @@ package com.lishid.openinv.commands;
 
 import com.lishid.openinv.OpenInv;
 import com.lishid.openinv.util.TabCompleter;
+import com.lishid.openinv.util.lang.Replacement;
 import java.util.Collections;
 import java.util.List;
 import org.bukkit.Chunk;
@@ -57,7 +58,10 @@ public class SearchContainerCommand implements TabExecutor {
         Material material = Material.getMaterial(args[0].toUpperCase());
 
         if (material == null) {
-            plugin.sendMessage(sender, "messages.error.invalidMaterial", "%target%", args[0]);
+            plugin.sendMessage(
+                    sender,
+                    "messages.error.invalidMaterial",
+                    new Replacement("%target%", args[0]));
             return false;
         }
 
@@ -100,13 +104,18 @@ public class SearchContainerCommand implements TabExecutor {
         if (locations.length() > 0) {
             locations.delete(locations.length() - 2, locations.length());
         } else {
-            plugin.sendMessage(sender, "messages.info.container.noMatches",
-                    "%target%", material.name());
+            plugin.sendMessage(
+                    sender,
+                    "messages.info.container.noMatches",
+                    new Replacement("%target%", material.name()));
             return true;
         }
 
-        plugin.sendMessage(sender, "messages.info.container.matches",
-                "%target%", material.name(), "%detail%", locations.toString());
+        plugin.sendMessage(
+                sender,
+                "messages.info.container.matches",
+                new Replacement("%target%", material.name()),
+                new Replacement("%detail%", locations.toString()));
         return true;
     }
 

--- a/plugin/src/main/java/com/lishid/openinv/commands/SearchEnchantCommand.java
+++ b/plugin/src/main/java/com/lishid/openinv/commands/SearchEnchantCommand.java
@@ -18,6 +18,7 @@ package com.lishid.openinv.commands;
 
 import com.lishid.openinv.OpenInv;
 import com.lishid.openinv.util.TabCompleter;
+import com.lishid.openinv.util.lang.Replacement;
 import java.util.Collections;
 import java.util.List;
 import org.bukkit.Material;
@@ -114,14 +115,18 @@ public class SearchEnchantCommand implements TabExecutor {
             // Matches found, delete trailing comma and space
             players.delete(players.length() - 2, players.length());
         } else {
-            plugin.sendMessage(sender, "messages.info.player.noMatches",
-                    "%target%", (enchant != null ? enchant.getKey().toString() : "") + " >= " + level);
+            plugin.sendMessage(
+                    sender,
+                    "messages.info.player.noMatches",
+                    new Replacement("%target%", (enchant != null ? enchant.getKey().toString() : "") + " >= " + level));
             return true;
         }
 
-        plugin.sendMessage(sender, "messages.info.player.matches",
-                "%target%", (enchant != null ? enchant.getKey().toString() : "") + " >= " + level,
-                "%detail%", players.toString());
+        plugin.sendMessage(
+                sender,
+                "messages.info.player.matches",
+                new Replacement("%target%", (enchant != null ? enchant.getKey().toString() : "") + " >= " + level),
+                        new Replacement("%detail%", players.toString()));
         return true;
     }
 

--- a/plugin/src/main/java/com/lishid/openinv/commands/SearchInvCommand.java
+++ b/plugin/src/main/java/com/lishid/openinv/commands/SearchInvCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2021 lishid. All rights reserved.
+ * Copyright (C) 2011-2022 lishid. All rights reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@ package com.lishid.openinv.commands;
 
 import com.lishid.openinv.OpenInv;
 import com.lishid.openinv.util.TabCompleter;
+import com.lishid.openinv.util.lang.Replacement;
 import java.util.Collections;
 import java.util.List;
 import org.bukkit.Material;
@@ -46,7 +47,10 @@ public class SearchInvCommand implements TabExecutor {
         }
 
         if (material == null) {
-            plugin.sendMessage(sender, "messages.error.invalidMaterial", "%target%", args.length > 0 ? args[0] : "null");
+            plugin.sendMessage(
+                    sender,
+                    "messages.error.invalidMaterial",
+                    new Replacement("%target%", args.length > 0 ? args[0] : "null"));
             return false;
         }
 
@@ -56,7 +60,10 @@ public class SearchInvCommand implements TabExecutor {
             try {
                 count = Integer.parseInt(args[1]);
             } catch (NumberFormatException ex) {
-                plugin.sendMessage(sender, "messages.error.invalidNumber", "%target%", args[1]);
+                plugin.sendMessage(
+                        sender,
+                        "messages.error.invalidNumber",
+                        new Replacement("%target%", args[1]));
                 return false;
             }
         }
@@ -74,13 +81,18 @@ public class SearchInvCommand implements TabExecutor {
         if (players.length() > 0) {
             players.delete(players.length() - 2, players.length());
         } else {
-            plugin.sendMessage(sender, "messages.info.player.noMatches",
-                    "%target%", material.name());
+            plugin.sendMessage(
+                    sender,
+                    "messages.info.player.noMatches",
+                    new Replacement("%target%", material.name()));
             return true;
         }
 
-        plugin.sendMessage(sender, "messages.info.player.matches",
-                "%target%", material.name(), "%detail%", players.toString());
+        plugin.sendMessage(
+                sender,
+                "messages.info.player.matches",
+                new Replacement("%target%", material.name()),
+                new Replacement("%detail%", players.toString()));
         return true;
     }
 

--- a/plugin/src/main/java/com/lishid/openinv/internal/OpenInventoryView.java
+++ b/plugin/src/main/java/com/lishid/openinv/internal/OpenInventoryView.java
@@ -17,6 +17,7 @@
 package com.lishid.openinv.internal;
 
 import com.lishid.openinv.OpenInv;
+import com.lishid.openinv.util.lang.Replacement;
 import java.util.Objects;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
@@ -73,8 +74,7 @@ public class OpenInventoryView extends InventoryView {
                     .getLocalizedMessage(
                             player,
                             titleKey,
-                            "%player%",
-                            owner.getName());
+                            new Replacement("%player%", owner.getName()));
             title = Objects.requireNonNullElseGet(localTitle, () -> owner.getName() + titleDefaultSuffix);
         }
 

--- a/plugin/src/main/java/com/lishid/openinv/util/lang/LanguageManager.java
+++ b/plugin/src/main/java/com/lishid/openinv/util/lang/LanguageManager.java
@@ -14,7 +14,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.lishid.openinv.util;
+package com.lishid.openinv.util.lang;
 
 import com.lishid.openinv.OpenInv;
 import java.io.BufferedReader;
@@ -147,19 +147,15 @@ public class LanguageManager {
         return value;
     }
 
-    public @Nullable String getValue(@NotNull String key, @Nullable String locale, String @NotNull ... replacements) {
-        if (replacements.length % 2 != 0) {
-            plugin.getLogger().log(Level.WARNING, "[LanguageManager] Replacement data is uneven", new Exception());
-        }
-
+    public @Nullable String getValue(@NotNull String key, @Nullable String locale, Replacement @NotNull ... replacements) {
         String value = getValue(key, locale);
 
         if (value == null) {
             return null;
         }
 
-        for (int i = 0; i < replacements.length; i += 2) {
-            value = value.replace(replacements[i], replacements[i + 1]);
+        for (Replacement replacement : replacements) {
+            value = value.replace(replacement.placeholder(), replacement.value());
         }
 
         return value;

--- a/plugin/src/main/java/com/lishid/openinv/util/lang/LanguageManager.java
+++ b/plugin/src/main/java/com/lishid/openinv/util/lang/LanguageManager.java
@@ -64,7 +64,7 @@ public class LanguageManager {
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(resourceStream))) {
                 localeConfigDefaults = YamlConfiguration.loadConfiguration(reader);
             } catch (IOException e) {
-                plugin.getLogger().log(Level.WARNING, "[LanguageManager] Unable to load resource " + locale + ".yml", e);
+                plugin.getLogger().log(Level.WARNING, e, () -> "[LanguageManager] Unable to load resource " + locale + ".yml");
                 localeConfigDefaults = new YamlConfiguration();
             }
         }
@@ -77,7 +77,7 @@ public class LanguageManager {
             try {
                 localeConfigDefaults.save(file);
             } catch (IOException e) {
-                plugin.getLogger().log(Level.WARNING, "[LanguageManager] Unable to save resource " + locale + ".yml", e);
+                plugin.getLogger().log(Level.WARNING, e, () -> "[LanguageManager] Unable to save resource " + locale + ".yml");
             }
         } else {
             localeConfig = YamlConfiguration.loadConfiguration(file);
@@ -98,11 +98,11 @@ public class LanguageManager {
             }
 
             if (!newKeys.isEmpty()) {
-                plugin.getLogger().info("[LanguageManager] Added new language keys: " + String.join(", ", newKeys));
+                plugin.getLogger().info(() -> "[LanguageManager] Added new language keys: " + String.join(", ", newKeys));
                 try {
                     localeConfig.save(file);
                 } catch (IOException e) {
-                    plugin.getLogger().log(Level.WARNING, "[LanguageManager] Unable to save resource " + locale + ".yml", e);
+                    plugin.getLogger().log(Level.WARNING, e, () -> "[LanguageManager] Unable to save resource " + locale + ".yml");
                 }
             }
         }
@@ -125,7 +125,7 @@ public class LanguageManager {
             }
 
             if (!newKeys.isEmpty()) {
-                plugin.getLogger().info("[LanguageManager] Missing translations from " + locale + ".yml: " + String.join(", ", newKeys));
+                plugin.getLogger().info(() -> "[LanguageManager] Missing translations from " + locale + ".yml: " + String.join(", ", newKeys));
             }
 
             // Fall through to default locale

--- a/plugin/src/main/java/com/lishid/openinv/util/lang/LanguageManager.java
+++ b/plugin/src/main/java/com/lishid/openinv/util/lang/LanguageManager.java
@@ -68,7 +68,8 @@ public class LanguageManager {
         if (!locale.equals(defaultLocale)) {
             addTranslationFallthrough(locale, localeConfig, file);
 
-            if (localeConfig.isConfigurationSection("guess")) {
+            if (plugin.getConfig().getBoolean("settings.secret.warn-about-guess-section", true)
+                    && localeConfig.isConfigurationSection("guess")) {
                 // Warn that guess section exists. This should run once per language per server restart
                 // when accessed by a user to hint to server owners that they can make UX improvements.
                 plugin.getLogger().info(() -> "[LanguageManager] Missing translations from " + locale + ".yml! Check the guess section!");

--- a/plugin/src/main/java/com/lishid/openinv/util/lang/Replacement.java
+++ b/plugin/src/main/java/com/lishid/openinv/util/lang/Replacement.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2011-2022 lishid. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.lishid.openinv.util.lang;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A data holder for string replacement in translations.
+ *
+ * @param placeholder the placeholder to be replaced
+ * @param value the value to insert
+ */
+public record Replacement(@NotNull String placeholder, @NotNull String value) {
+
+}


### PR DESCRIPTION
 * Clarify replacements internally to reduce the likelihood of messing up when including new ones
 * Fix missing keys not being written to disk for easy translation
 * Use a guessfile-like system where missing translation keys are inserted into a separate section for easy identification
 * Reduce verbosity of missing keys warning

Partially addresses #85 