### PR TITLE
Clamp /searchcontainer radius

### DIFF
--- a/plugin/src/main/java/com/lishid/openinv/commands/SearchContainerCommand.java
+++ b/plugin/src/main/java/com/lishid/openinv/commands/SearchContainerCommand.java
@@ -76,6 +76,10 @@ public class SearchContainerCommand implements TabExecutor {
             }
         }
 
+        // Clamp radius.
+        int configMax = Math.max(0, plugin.getConfig().getInt("settings.command.searchcontainer.max-radius", 10));
+        radius = Math.max(0, Math.min(radius, configMax));
+
         World world = senderPlayer.getWorld();
         Chunk centerChunk = senderPlayer.getLocation().getChunk();
         StringBuilder locations = new StringBuilder();

--- a/plugin/src/main/java/com/lishid/openinv/commands/SearchContainerCommand.java
+++ b/plugin/src/main/java/com/lishid/openinv/commands/SearchContainerCommand.java
@@ -77,7 +77,7 @@ public class SearchContainerCommand implements TabExecutor {
         }
 
         // Clamp radius.
-        int configMax = Math.max(0, plugin.getConfig().getInt("settings.command.searchcontainer.max-radius", 10));
+        int configMax = plugin.getConfig().getInt("settings.command.searchcontainer.max-radius", 10);
         radius = Math.max(0, Math.min(radius, configMax));
 
         World world = senderPlayer.getWorld();

--- a/plugin/src/main/java/com/lishid/openinv/util/ConfigUpdater.java
+++ b/plugin/src/main/java/com/lishid/openinv/util/ConfigUpdater.java
@@ -71,6 +71,7 @@ public record ConfigUpdater(OpenInv plugin) {
     private void updateConfig5To6() {
         plugin.getServer().getScheduler().runTask(plugin, () -> {
             plugin.getConfig().set("settings.command.open.no-args-opens-self", false);
+            plugin.getConfig().set("settings.command.searchcontainer.max-radius", 10);
             plugin.getConfig().set("config-version", 6);
         });
     }

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -3,6 +3,8 @@ settings:
   command:
     open:
       no-args-opens-self: false
+    searchcontainer:
+      max-radius: 10
   disable-offline-access: false
   disable-saving: false
   locale: 'en_us'


### PR DESCRIPTION
Default max is 10 because that's the default server view distance. Those chunks should (theoretically) already be loaded.

Related to lishid#188

<sub><sub><sub>Please use a tracking plugin like Prism or CoreProtect instead of this command. This is not a good replacement for logs.</sub></sub></sub>