### PR TITLE
Fix game type not loading

### DIFF
--- a/internal/v1_19_R3/src/main/java/com/lishid/openinv/internal/v1_19_R3/OpenPlayer.java
+++ b/internal/v1_19_R3/src/main/java/com/lishid/openinv/internal/v1_19_R3/OpenPlayer.java
@@ -41,9 +41,11 @@ public class OpenPlayer extends CraftPlayer {
     @Override
     public void loadData() {
         // See CraftPlayer#loadData
-        CompoundTag loaded = this.server.getHandle().playerIo.load(this.getHandle());
+        ServerPlayer serverPlayer = getHandle();
+        CompoundTag loaded = this.server.getHandle().playerIo.load(serverPlayer);
         if (loaded != null) {
-            getHandle().readAdditionalSaveData(loaded);
+            serverPlayer.readAdditionalSaveData(loaded);
+            serverPlayer.loadGameTypes(loaded);
         }
     }
 

--- a/internal/v1_19_R3/src/main/java/com/lishid/openinv/internal/v1_19_R3/PlayerDataManager.java
+++ b/internal/v1_19_R3/src/main/java/com/lishid/openinv/internal/v1_19_R3/PlayerDataManager.java
@@ -21,8 +21,6 @@ import com.lishid.openinv.internal.IPlayerDataManager;
 import com.lishid.openinv.internal.ISpecialInventory;
 import com.lishid.openinv.internal.OpenInventoryView;
 import com.mojang.authlib.GameProfile;
-import java.lang.reflect.Field;
-import java.util.logging.Logger;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket;
@@ -46,6 +44,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.InventoryView;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.util.logging.Logger;
 
 public class PlayerDataManager implements IPlayerDataManager {
 
@@ -123,6 +124,7 @@ public class PlayerDataManager implements IPlayerDataManager {
 
         // Also read "extra" data.
         entity.readAdditionalSaveData(loadedData);
+        entity.loadGameTypes(loadedData);
 
         if (entity.level == null) {
             // Paper: Move player to spawn

--- a/internal/v1_20_R2/src/main/java/com/lishid/openinv/internal/v1_20_R2/PlayerDataManager.java
+++ b/internal/v1_20_R2/src/main/java/com/lishid/openinv/internal/v1_20_R2/PlayerDataManager.java
@@ -177,6 +177,8 @@ public class PlayerDataManager implements IPlayerDataManager {
         player.load(loadedData);
         // Also read "extra" data.
         player.readAdditionalSaveData(loadedData);
+        // Game type settings are also loaded separately.
+        player.loadGameTypes(loadedData);
 
         if (paper) {
             // Paper: world is not loaded by ServerPlayer#load(CompoundTag).

--- a/internal/v1_20_R3/src/main/java/com/lishid/openinv/internal/v1_20_R3/PlayerDataManager.java
+++ b/internal/v1_20_R3/src/main/java/com/lishid/openinv/internal/v1_20_R3/PlayerDataManager.java
@@ -177,6 +177,8 @@ public class PlayerDataManager implements IPlayerDataManager {
         player.load(loadedData);
         // Also read "extra" data.
         player.readAdditionalSaveData(loadedData);
+        // Game type settings are also loaded separately.
+        player.loadGameTypes(loadedData);
 
         if (paper) {
             // Paper: world is not loaded by ServerPlayer#load(CompoundTag).


### PR DESCRIPTION
Game type saving is handled by `ServerPlayer#addAdditionalSaveData` but game type is not loaded by `ServerPlayer#readAdditionalSaveData`.