### PR TITLE
Improve compatibility with custom NBT

### DIFF
--- a/internal/v1_19_R3/src/main/java/com/lishid/openinv/internal/v1_19_R3/OpenPlayer.java
+++ b/internal/v1_19_R3/src/main/java/com/lishid/openinv/internal/v1_19_R3/OpenPlayer.java
@@ -19,7 +19,6 @@ package com.lishid.openinv.internal.v1_19_R3;
 import net.minecraft.Util;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtIo;
-import net.minecraft.nbt.NbtUtils;
 import net.minecraft.nbt.NumericTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerPlayer;
@@ -27,12 +26,47 @@ import net.minecraft.world.level.storage.PlayerDataStorage;
 import org.apache.logging.log4j.LogManager;
 import org.bukkit.craftbukkit.v1_19_R3.CraftServer;
 import org.bukkit.craftbukkit.v1_19_R3.entity.CraftPlayer;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.util.Set;
 
 public class OpenPlayer extends CraftPlayer {
+
+    private static final Set<String> RESET_TAGS = Set.of(
+        // net.minecraft.world.Entity#saveWithoutId(CompoundTag)
+        "CustomName",
+        "CustomNameVisible",
+        "Silent",
+        "NoGravity",
+        "Glowing",
+        "TicksFrozen",
+        "HasVisualFire",
+        "Tags",
+        "Passengers",
+        // net.minecraft.server.level.ServerPlayer#addAdditionalSaveData(CompoundTag)
+        // Intentional omissions to prevent mount loss: Attach, Entity, and RootVehicle
+        "warden_spawn_tracker",
+        "enteredNetherPosition",
+        "SpawnX",
+        "SpawnY",
+        "SpawnZ",
+        "SpawnForced",
+        "SpawnAngle",
+        "SpawnDimension",
+        // net.minecraft.world.entity.player.Player#addAdditionalSaveData(CompoundTag)
+        "ShoulderEntityLeft",
+        "ShoulderEntityRight",
+        "LastDeathLocation",
+        // net.minecraft.world.entity.LivingEntity#addAdditionalSaveData(CompoundTag)
+        "ActiveEffects",
+        "SleepingX",
+        "SleepingY",
+        "SleepingZ",
+        "Brain"
+    );
 
     public OpenPlayer(CraftServer server, ServerPlayer entity) {
         super(server, entity);
@@ -56,12 +90,13 @@ public class OpenPlayer extends CraftPlayer {
         try {
             PlayerDataStorage worldNBTStorage = player.server.getPlayerList().playerIo;
 
-            CompoundTag playerData = player.saveWithoutId(new CompoundTag());
+            CompoundTag oldData = isOnline() ? null : worldNBTStorage.load(player);
+            CompoundTag playerData = getWritableTag(oldData);
+            playerData = player.saveWithoutId(playerData);
             setExtraData(playerData);
 
-            if (!isOnline()) {
-                // Preserve certain data when offline.
-                CompoundTag oldData = worldNBTStorage.load(player);
+            if (oldData != null) {
+                // Revert certain special data values when offline.
                 revertSpecialValues(playerData, oldData);
             }
 
@@ -75,27 +110,22 @@ public class OpenPlayer extends CraftPlayer {
         }
     }
 
-    private void revertSpecialValues(@NotNull CompoundTag newData, @Nullable CompoundTag oldData) {
+    @Contract("null -> new")
+    private @NotNull CompoundTag getWritableTag(@Nullable CompoundTag oldData) {
         if (oldData == null) {
-            return;
+            return new CompoundTag();
         }
 
-        // Prevent vehicle deletion.
-        if (oldData.contains("RootVehicle", Tag.TAG_COMPOUND)) {
-            // See net.minecraft.server.players.PlayerList#save(ServerPlayer)
-            // See net.minecraft.server.level.ServerPlayer#addAdditionalSaveData(CompoundTag)
-            try {
-                Tag attach = oldData.get("Attach");
-                if (attach != null) {
-                    newData.putUUID("Attach", NbtUtils.loadUUID(attach));
-                }
-            } catch (IllegalArgumentException ignored) {
-                // Likely will not re-mount successfully, but at least the mount will not be deleted.
-            }
-            newData.put("Entity", oldData.getCompound("Entity"));
-            newData.put("RootVehicle", oldData.getCompound("RootVehicle"));
-        }
+        // Copy old data. This is a deep clone, so operating on it should be safe.
+        oldData = oldData.copy();
 
+        // Remove vanilla/server data that is not written every time.
+        oldData.getAllKeys().removeIf(key -> RESET_TAGS.contains(key) || key.startsWith("Bukkit"));
+
+        return oldData;
+    }
+
+    private void revertSpecialValues(@NotNull CompoundTag newData, @NotNull CompoundTag oldData) {
         // Revert automatic updates to play timestamps.
         copyValue(oldData, newData, "bukkit", "lastPlayed", NumericTag.class);
         copyValue(oldData, newData, "Paper", "LastSeen", NumericTag.class);
@@ -111,8 +141,8 @@ public class OpenPlayer extends CraftPlayer {
         CompoundTag oldContainer = getTag(source, container, CompoundTag.class);
         CompoundTag newContainer = getTag(target, container, CompoundTag.class);
 
-        // Container being null means the server implementation doesn't store this data.
-        if (oldContainer == null || newContainer == null) {
+        // New container being null means the server implementation doesn't store this data.
+        if (newContainer == null) {
             return;
         }
 
@@ -121,9 +151,12 @@ public class OpenPlayer extends CraftPlayer {
     }
 
     private <T extends Tag> @Nullable T getTag(
-        @NotNull CompoundTag container,
+        @Nullable CompoundTag container,
         @NotNull String key,
         @NotNull Class<T> dataType) {
+        if (container == null) {
+            return null;
+        }
         Tag value = container.get(key);
         if (value == null || !dataType.isAssignableFrom(value.getClass())) {
             return null;

--- a/internal/v1_20_R2/src/main/java/com/lishid/openinv/internal/v1_20_R2/OpenPlayer.java
+++ b/internal/v1_20_R2/src/main/java/com/lishid/openinv/internal/v1_20_R2/OpenPlayer.java
@@ -20,19 +20,54 @@ import com.mojang.logging.LogUtils;
 import net.minecraft.Util;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtIo;
-import net.minecraft.nbt.NbtUtils;
 import net.minecraft.nbt.NumericTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.storage.PlayerDataStorage;
 import org.bukkit.craftbukkit.v1_20_R2.CraftServer;
 import org.bukkit.craftbukkit.v1_20_R2.entity.CraftPlayer;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.util.Set;
 
 public class OpenPlayer extends CraftPlayer {
+
+    private static final Set<String> RESET_TAGS = Set.of(
+        // net.minecraft.world.Entity#saveWithoutId(CompoundTag)
+        "CustomName",
+        "CustomNameVisible",
+        "Silent",
+        "NoGravity",
+        "Glowing",
+        "TicksFrozen",
+        "HasVisualFire",
+        "Tags",
+        "Passengers",
+        // net.minecraft.server.level.ServerPlayer#addAdditionalSaveData(CompoundTag)
+        // Intentional omissions to prevent mount loss: Attach, Entity, and RootVehicle
+        "warden_spawn_tracker",
+        "enteredNetherPosition",
+        "SpawnX",
+        "SpawnY",
+        "SpawnZ",
+        "SpawnForced",
+        "SpawnAngle",
+        "SpawnDimension",
+        // net.minecraft.world.entity.player.Player#addAdditionalSaveData(CompoundTag)
+        "ShoulderEntityLeft",
+        "ShoulderEntityRight",
+        "LastDeathLocation",
+        // net.minecraft.world.entity.LivingEntity#addAdditionalSaveData(CompoundTag)
+        "ActiveEffects", // Backwards compat: Renamed from 1.19
+        "active_effects",
+        "SleepingX",
+        "SleepingY",
+        "SleepingZ",
+        "Brain"
+    );
 
     public OpenPlayer(CraftServer server, ServerPlayer entity) {
         super(server, entity);
@@ -50,12 +85,13 @@ public class OpenPlayer extends CraftPlayer {
         try {
             PlayerDataStorage worldNBTStorage = player.server.getPlayerList().playerIo;
 
-            CompoundTag playerData = player.saveWithoutId(new CompoundTag());
+            CompoundTag oldData = isOnline() ? null : worldNBTStorage.load(player);
+            CompoundTag playerData = getWritableTag(oldData);
+            playerData = player.saveWithoutId(playerData);
             setExtraData(playerData);
 
-            if (!isOnline()) {
-                // Preserve certain data when offline.
-                CompoundTag oldData = worldNBTStorage.load(player);
+            if (oldData != null) {
+                // Revert certain special data values when offline.
                 revertSpecialValues(playerData, oldData);
             }
 
@@ -69,27 +105,22 @@ public class OpenPlayer extends CraftPlayer {
         }
     }
 
-    private void revertSpecialValues(@NotNull CompoundTag newData, @Nullable CompoundTag oldData) {
+    @Contract("null -> new")
+    private @NotNull CompoundTag getWritableTag(@Nullable CompoundTag oldData) {
         if (oldData == null) {
-            return;
+            return new CompoundTag();
         }
 
-        // Prevent vehicle deletion.
-        if (oldData.contains("RootVehicle", Tag.TAG_COMPOUND)) {
-            // See net.minecraft.server.players.PlayerList#save(ServerPlayer)
-            // See net.minecraft.server.level.ServerPlayer#addAdditionalSaveData(CompoundTag)
-            try {
-                Tag attach = oldData.get("Attach");
-                if (attach != null) {
-                    newData.putUUID("Attach", NbtUtils.loadUUID(attach));
-                }
-            } catch (IllegalArgumentException ignored) {
-                // Likely will not re-mount successfully, but at least the mount will not be deleted.
-            }
-            newData.put("Entity", oldData.getCompound("Entity"));
-            newData.put("RootVehicle", oldData.getCompound("RootVehicle"));
-        }
+        // Copy old data. This is a deep clone, so operating on it should be safe.
+        oldData = oldData.copy();
 
+        // Remove vanilla/server data that is not written every time.
+        oldData.getAllKeys().removeIf(key -> RESET_TAGS.contains(key) || key.startsWith("Bukkit"));
+
+        return oldData;
+    }
+
+    private void revertSpecialValues(@NotNull CompoundTag newData, @NotNull CompoundTag oldData) {
         // Revert automatic updates to play timestamps.
         copyValue(oldData, newData, "bukkit", "lastPlayed", NumericTag.class);
         copyValue(oldData, newData, "Paper", "LastSeen", NumericTag.class);
@@ -105,8 +136,8 @@ public class OpenPlayer extends CraftPlayer {
         CompoundTag oldContainer = getTag(source, container, CompoundTag.class);
         CompoundTag newContainer = getTag(target, container, CompoundTag.class);
 
-        // Container being null means the server implementation doesn't store this data.
-        if (oldContainer == null || newContainer == null) {
+        // New container being null means the server implementation doesn't store this data.
+        if (newContainer == null) {
             return;
         }
 
@@ -115,9 +146,12 @@ public class OpenPlayer extends CraftPlayer {
     }
 
     private <T extends Tag> @Nullable T getTag(
-        @NotNull CompoundTag container,
+        @Nullable CompoundTag container,
         @NotNull String key,
         @NotNull Class<T> dataType) {
+        if (container == null) {
+            return null;
+        }
         Tag value = container.get(key);
         if (value == null || !dataType.isAssignableFrom(value.getClass())) {
             return null;

--- a/internal/v1_20_R3/src/main/java/com/lishid/openinv/internal/v1_20_R3/OpenPlayer.java
+++ b/internal/v1_20_R3/src/main/java/com/lishid/openinv/internal/v1_20_R3/OpenPlayer.java
@@ -62,6 +62,7 @@ public class OpenPlayer extends CraftPlayer {
         "ShoulderEntityRight",
         "LastDeathLocation",
         // net.minecraft.world.entity.LivingEntity#addAdditionalSaveData(CompoundTag)
+        "ActiveEffects", // Backwards compat: Renamed from 1.19
         "active_effects",
         "SleepingX",
         "SleepingY",

--- a/internal/v1_20_R3/src/main/java/com/lishid/openinv/internal/v1_20_R3/OpenPlayer.java
+++ b/internal/v1_20_R3/src/main/java/com/lishid/openinv/internal/v1_20_R3/OpenPlayer.java
@@ -58,7 +58,8 @@ public class OpenPlayer extends CraftPlayer {
         "SpawnAngle",
         "SpawnDimension",
         // net.minecraft.world.entity.player.Player#addAdditionalSaveData(CompoundTag)
-        // Intentional omissions to prevent pet loss: ShoulderEntityLeft, ShoulderEntityRight
+        "ShoulderEntityLeft",
+        "ShoulderEntityRight",
         "LastDeathLocation",
         // net.minecraft.world.entity.LivingEntity#addAdditionalSaveData(CompoundTag)
         "active_effects",

--- a/internal/v1_20_R3/src/main/java/com/lishid/openinv/internal/v1_20_R3/OpenPlayer.java
+++ b/internal/v1_20_R3/src/main/java/com/lishid/openinv/internal/v1_20_R3/OpenPlayer.java
@@ -136,8 +136,8 @@ public class OpenPlayer extends CraftPlayer {
         CompoundTag oldContainer = getTag(source, container, CompoundTag.class);
         CompoundTag newContainer = getTag(target, container, CompoundTag.class);
 
-        // Container being null means the server implementation doesn't store this data.
-        if (oldContainer == null || newContainer == null) {
+        // New container being null means the server implementation doesn't store this data.
+        if (newContainer == null) {
             return;
         }
 
@@ -146,9 +146,12 @@ public class OpenPlayer extends CraftPlayer {
     }
 
     private <T extends Tag> @Nullable T getTag(
-        @NotNull CompoundTag container,
+        @Nullable CompoundTag container,
         @NotNull String key,
         @NotNull Class<T> dataType) {
+        if (container == null) {
+            return null;
+        }
         Tag value = container.get(key);
         if (value == null || !dataType.isAssignableFrom(value.getClass())) {
             return null;

--- a/internal/v1_20_R3/src/main/java/com/lishid/openinv/internal/v1_20_R3/OpenPlayer.java
+++ b/internal/v1_20_R3/src/main/java/com/lishid/openinv/internal/v1_20_R3/OpenPlayer.java
@@ -49,21 +49,23 @@ public class OpenPlayer extends CraftPlayer {
         "Passengers",
         // net.minecraft.server.level.ServerPlayer#addAdditionalSaveData(CompoundTag)
         // Intentional omissions to prevent mount loss: Attach, Entity, and RootVehicle
-        // SpawnX, SpawnY, etc. in #RESET_TAG_PREFIXES via Spawn
         "warden_spawn_tracker",
         "enteredNetherPosition",
+        "SpawnX",
+        "SpawnY",
+        "SpawnZ",
+        "SpawnForced",
+        "SpawnAngle",
+        "SpawnDimension",
         // net.minecraft.world.entity.player.Player#addAdditionalSaveData(CompoundTag)
         // Intentional omissions to prevent pet loss: ShoulderEntityLeft, ShoulderEntityRight
         "LastDeathLocation",
         // net.minecraft.world.entity.LivingEntity#addAdditionalSaveData(CompoundTag)
-        // SleepingX etc. in #RESET_TAG_PREFIXES
         "active_effects",
+        "SleepingX",
+        "SleepingY",
+        "SleepingZ",
         "Brain"
-    );
-    private static final Set<String> RESET_TAG_PREFIXES = Set.of(
-        "Bukkit", // Flags for re-enabling Bukkit API features
-        "Spawn", // SpawnX etc. only set if respawnPosition not null
-        "Sleeping" // SleepingX etc. only set if sleeping pos is set
     );
 
     public OpenPlayer(CraftServer server, ServerPlayer entity) {
@@ -114,8 +116,7 @@ public class OpenPlayer extends CraftPlayer {
 
         // Remove vanilla/server data that is not written every time.
         oldData.getAllKeys()
-            .removeIf(key -> RESET_TAGS.contains(key)
-                || RESET_TAG_PREFIXES.stream().anyMatch(key::startsWith));
+            .removeIf(key -> RESET_TAGS.contains(key) || key.startsWith("Bukkit"));
 
         return oldData;
     }

--- a/internal/v1_20_R3/src/main/java/com/lishid/openinv/internal/v1_20_R3/OpenPlayer.java
+++ b/internal/v1_20_R3/src/main/java/com/lishid/openinv/internal/v1_20_R3/OpenPlayer.java
@@ -92,6 +92,14 @@ public class OpenPlayer extends CraftPlayer {
             newData.put("RootVehicle", oldData.getCompound("RootVehicle"));
         }
 
+        // TODO: Better-support arbitrary non-vanilla data
+        //  Blacklist vanilla root tags, copy all others
+        //  Should do this BEFORE calling #setExtraData to not clobber additional info from server impl that we should load properly
+        CompoundTag myWorlds = getTag(oldData, "MyWorlds", CompoundTag.class);
+        if (myWorlds != null) {
+            newData.put("MyWorlds", myWorlds);
+        }
+
         // Revert automatic updates to play timestamps.
         copyValue(oldData, newData, "bukkit", "lastPlayed", NumericTag.class);
         copyValue(oldData, newData, "Paper", "LastSeen", NumericTag.class);


### PR DESCRIPTION
Improve compatibility with plugins that add arbitrary NBT. This works by copying the player's old data and writing the current data into it after removing a list of tags that the server is will not clobber if the corresponding internal values are not set. This does make updates marginally more complex, but a good chunk of the save code already needed to be reviewed, so it's not a huge deal.

This will not support ancient data versions - tags are not removed if they no longer exist in a supported version. It is assumed that when you upgrade your server you upgrade your world and players in a reasonable amount of time. In cases where data has not been upgraded in several major versions, it is possible that a very old tag may be preserved and clobber changes made via OI when it is converted into a modern copy.
For example, in 1.20 the tag `ActiveEffects` was replaced by `active_effects`. In 1.21, this will become an unsupported tag due to not having been present in the previous version. If a plugin were to load a player in 1.21 whose data had not been upgraded from the 1.19 format, OI would preserve the `ActiveEffects` tag, which would likely clobber any data in `active_effects` next load. This would result in potion effects appearing to not save.

Closes #182 