### PR TITLE
Add fallthrough to "parent" language

### DIFF
--- a/common/src/main/java/com/lishid/openinv/util/lang/LanguageManager.java
+++ b/common/src/main/java/com/lishid/openinv/util/lang/LanguageManager.java
@@ -225,8 +225,8 @@ public class LanguageManager {
     }
 
     public @Nullable String getValue(@NotNull String key, @Nullable String locale) {
-        String value = getOrLoadLocale(locale == null ? defaultLocale : locale.toLowerCase(Locale.ROOT)).getString(key);
-        if (value == null || value.isEmpty()) {
+        String value = getOrLoadLocale(locale == null ? defaultLocale : locale.toLowerCase(Locale.ENGLISH)).getString(key);
+        if (value == null || value.isBlank()) {
             return null;
         }
 

--- a/plugin/src/main/java/com/lishid/openinv/OpenInv.java
+++ b/plugin/src/main/java/com/lishid/openinv/OpenInv.java
@@ -32,6 +32,7 @@ import com.lishid.openinv.internal.ISpecialInventory;
 import com.lishid.openinv.internal.ISpecialPlayerInventory;
 import com.lishid.openinv.util.ConfigUpdater;
 import com.lishid.openinv.util.InternalAccessor;
+import com.lishid.openinv.util.LangMigrator;
 import com.lishid.openinv.util.Permissions;
 import com.lishid.openinv.util.StringMetric;
 import com.lishid.openinv.util.lang.LanguageManager;
@@ -51,6 +52,7 @@ import org.bukkit.profile.PlayerProfile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
@@ -83,6 +85,7 @@ public class OpenInv extends JavaPlugin implements IOpenInv {
     @Override
     public void reloadConfig() {
         super.reloadConfig();
+        languageManager.reload();
         this.offlineHandler = disableOfflineAccess() ? OfflineHandler.REMOVE_AND_CLOSE : OfflineHandler.REQUIRE_PERMISSIONS;
         if (this.accessor != null && this.accessor.isSupported()) {
             this.accessor.reload(this.getConfig());
@@ -128,7 +131,11 @@ public class OpenInv extends JavaPlugin implements IOpenInv {
         // Save default configuration if not present.
         this.saveDefaultConfig();
 
-        this.languageManager = new LanguageManager(this, "en_us");
+        // Migrate locale files to a subfolder.
+        Path dataFolder = getDataFolder().toPath();
+        new LangMigrator(dataFolder, dataFolder.resolve("locale"), getLogger()).migrate();
+
+        this.languageManager = new LanguageManager(this, "en");
         this.accessor = new InternalAccessor(getLogger(), languageManager);
 
         try {

--- a/plugin/src/main/java/com/lishid/openinv/util/LangMigrator.java
+++ b/plugin/src/main/java/com/lishid/openinv/util/LangMigrator.java
@@ -1,0 +1,87 @@
+package com.lishid.openinv.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class LangMigrator {
+
+  private final @NotNull Path oldFolder;
+  private final @NotNull Path newFolder;
+  private final @NotNull Logger logger;
+
+  public LangMigrator(@NotNull Path oldFolder, @NotNull Path newFolder, @NotNull Logger logger) {
+    this.oldFolder = oldFolder;
+    this.newFolder = newFolder;
+    this.logger = logger;
+  }
+
+  public void migrate() {
+    if (!Files.exists(oldFolder.resolve("en_us.yml"))) {
+      // Probably already migrated.
+      return;
+    }
+
+    logger.info(() -> String.format("[LanguageManager] Migrating language files to %s", newFolder));
+
+    if (!Files.exists(newFolder)) {
+      try {
+        Files.createDirectories(newFolder);
+      } catch (IOException e) {
+        logger.log(Level.WARNING, "Unable to create language subdirectory!", e);
+      }
+    }
+
+    try (DirectoryStream<Path> files = Files.newDirectoryStream(oldFolder)) {
+      files.forEach(path -> {
+        if (path == null) {
+          return;
+        }
+
+        String fileName = path.getFileName().toString();
+
+        if (fileName.startsWith("config") || !fileName.endsWith(".yml")) {
+          return;
+        }
+
+        // Migrate certain files to be parent languages.
+        fileName = switch (fileName) {
+          case "en_us.yml" -> "en.yml";
+          case "de_de.yml" -> "de.yml";
+          case "es_es.yml" -> "es.yml";
+          case "pt_br.yml" -> "pt.yml";
+          default -> fileName;
+        };
+
+        try {
+          Files.copy(path, newFolder.resolve(fileName));
+          Files.delete(path);
+        } catch (FileAlreadyExistsException e1) {
+          // File already migrated?
+          try {
+            Files.copy(path, newFolder.resolve("old_" + fileName));
+            Files.delete(path);
+          } catch (IOException e2) {
+            // If it fails again, just re-throw.
+            throw new UncheckedIOException(e2);
+          }
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+      });
+    } catch (UncheckedIOException e) {
+      logger.log(Level.WARNING, "Unable to migrate languages to subdirectory!", e.getCause());
+    } catch (IOException e) {
+      logger.log(Level.WARNING, "Unable to migrate languages to subdirectory!", e);
+    }
+
+  }
+
+}

--- a/plugin/src/main/resources/locale/de.yml
+++ b/plugin/src/main/resources/locale/de.yml
@@ -23,8 +23,8 @@ messages:
     container:
       noMatches: 'Keine Container mit %target% gefunden.'
       matches: 'Container hat %target%: %detail%'
-    on: 'an'
-    off: 'aus'
+    'on': 'an'
+    'off': 'aus'
 container:
   player: '%player%''s Inventar'
   enderchest: '%player%''s Endertruhe'

--- a/plugin/src/main/resources/locale/en.yml
+++ b/plugin/src/main/resources/locale/en.yml
@@ -23,8 +23,8 @@ messages:
     container:
       noMatches: 'No containers found with %target%.'
       matches: 'Containers holding %target%: %detail%'
-    on: 'on'
-    off: 'off'
+    'on': 'on'
+    'off': 'off'
 container:
   player: '%player%''s Inventory'
   enderchest: '%player%''s Ender Chest'

--- a/plugin/src/main/resources/locale/es.yml
+++ b/plugin/src/main/resources/locale/es.yml
@@ -23,8 +23,8 @@ messages:
     container:
       noMatches: 'No se encontraron contenedores con %target%.'
       matches: 'Contenedores con %target%: %detail%'
-    on: 'activado'
-    off: 'desactivado'
+    'on': 'activado'
+    'off': 'desactivado'
 container:
   player: 'Inventario de %player%'
   enderchest: 'Cofre de Ender de %player%'

--- a/plugin/src/main/resources/locale/pt.yml
+++ b/plugin/src/main/resources/locale/pt.yml
@@ -23,8 +23,8 @@ messages:
     container:
       noMatches: 'Nenhum recipiente encontrado com %target%.'
       matches: 'Recipientes contendo %target%: %detail%'
-    on: 'ligado'
-    off: 'desligado'
+    'on': 'ligado'
+    'off': 'desligado'
 container:
   player: 'Inventario de %player%'
   enderchest: 'Bau de Ender de %player%'

--- a/plugin/src/main/resources/locale/zh_cn.yml
+++ b/plugin/src/main/resources/locale/zh_cn.yml
@@ -24,8 +24,8 @@ messages:
     container:
       noMatches: 找不到放有 %target% 的储物箱。
       matches: '找到放有 %target% 的储物箱 ： %detail%'
-    'true': '开启'
-    'false': '关闭'
+    'on': '开启'
+    'off': '关闭'
 container:
   player: '%player% 的物品栏'
   enderchest: '%player% 的末影箱' 

--- a/plugin/src/main/resources/locale/zh_tw.yml
+++ b/plugin/src/main/resources/locale/zh_tw.yml
@@ -24,8 +24,8 @@ messages:
     container:
       noMatches: 找不到放有 %target% 的儲物箱。
       matches: '找到放有 %target% 的儲物箱 ： %detail%'
-    'true': '開啟'
-    'false': '關閉'
+    'on': '開啟'
+    'off': '關閉'
 container:
   player: '%player% 的物品欄'
   enderchest: '%player% 的終界箱'


### PR DESCRIPTION
Reduce load on server owners who want to modify language files - easier way to do bulk edits.  
<sub><sub><sub>"I'm making it easier for server owners to change languages," he says after pushing towards using more resource-pack-based translations. "This is good," he says.</sub></sub></sub>

TODO
* [x] Move languages to a subfolder in the file system
* [x] Use `en` for default instead of `en_us`
* [x] Is reloaded with config reload (not that OpenInv currently offers a way to do this, but hey)

Closes #85