### PR TITLE
Fix the unknown texture error caused by a non-existent texture

### DIFF
--- a/resource-pack/assets/minecraft/models/item/white_stained_glass_pane.json
+++ b/resource-pack/assets/minecraft/models/item/white_stained_glass_pane.json
@@ -1,7 +1,7 @@
 {
   "parent": "minecraft:item/generated",
   "textures": {
-    "layer0": "minecraft:item/white_stained_glass_pane"
+    "layer0": "minecraft:block/white_stained_glass"
   },
   "overrides": [
     {


### PR DESCRIPTION
Because minecraft:item/white_stained_glass_pane does not exist, a texture error occurs. The fix is simple: just follow the format of Minecraft's assets.

![image](https://github.com/user-attachments/assets/32b6a03f-7ef9-4858-9432-c0f37600f44e)

white_stained_glass_pane.json extracted from Minecraft:
```json
{
  "parent": "minecraft:item/generated",
  "textures": {
    "layer0": "minecraft:block/white_stained_glass"
  }
}
```