### PR TITLE
Add equal access behavior config

### DIFF
--- a/common/src/main/java/com/lishid/openinv/internal/PlayerManager.java
+++ b/common/src/main/java/com/lishid/openinv/internal/PlayerManager.java
@@ -49,6 +49,6 @@ public interface PlayerManager {
      *`
      * @return the InventoryView opened
      */
-    @Nullable InventoryView openInventory(@NotNull Player player, @NotNull ISpecialInventory inventory);
+    @Nullable InventoryView openInventory(@NotNull Player player, @NotNull ISpecialInventory inventory, boolean viewOnly);
 
 }

--- a/internal/v1_20_R3/src/main/java/com/lishid/openinv/internal/v1_20_R3/PlayerManager.java
+++ b/internal/v1_20_R3/src/main/java/com/lishid/openinv/internal/v1_20_R3/PlayerManager.java
@@ -239,7 +239,7 @@ public class PlayerManager implements com.lishid.openinv.internal.PlayerManager 
     }
 
     @Override
-    public @Nullable InventoryView openInventory(@NotNull Player player, @NotNull ISpecialInventory inventory) {
+    public @Nullable InventoryView openInventory(@NotNull Player player, @NotNull ISpecialInventory inventory, boolean viewOnly) {
 
         ServerPlayer nmsPlayer = getHandle(player);
 

--- a/internal/v1_20_R4/src/main/java/com/lishid/openinv/internal/v1_20_R4/PlayerManager.java
+++ b/internal/v1_20_R4/src/main/java/com/lishid/openinv/internal/v1_20_R4/PlayerManager.java
@@ -239,7 +239,7 @@ public class PlayerManager implements com.lishid.openinv.internal.PlayerManager 
     }
 
     @Override
-    public @Nullable InventoryView openInventory(@NotNull Player player, @NotNull ISpecialInventory inventory) {
+    public @Nullable InventoryView openInventory(@NotNull Player player, @NotNull ISpecialInventory inventory, boolean viewOnly) {
 
         ServerPlayer nmsPlayer = getHandle(player);
 

--- a/internal/v1_21_R1/src/main/java/com/lishid/openinv/internal/v1_21_R1/container/OpenEnderChest.java
+++ b/internal/v1_21_R1/src/main/java/com/lishid/openinv/internal/v1_21_R1/container/OpenEnderChest.java
@@ -9,8 +9,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.ContainerHelper;
-import net.minecraft.world.MenuProvider;
-import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.player.StackedContents;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -27,8 +25,8 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class OpenEnderChest implements Container, StackedContentsCompatible, MenuProvider,
-    InternalOwned<ServerPlayer>, ISpecialEnderChest {
+public class OpenEnderChest implements Container, StackedContentsCompatible, InternalOwned<ServerPlayer>,
+    ISpecialEnderChest {
 
   private CraftInventory inventory;
   private @NotNull ServerPlayer owner;
@@ -182,17 +180,15 @@ public class OpenEnderChest implements Container, StackedContentsCompatible, Men
     }
   }
 
-  @Override
-  public Component getDisplayName() {
+  public Component getTitle() {
     return Component.translatableWithFallback("openinv.container.enderchest.prefix", "", owner.getName())
         .append(Component.translatable("container.enderchest"))
         .append(Component.translatableWithFallback("openinv.container.enderchest.suffix", " - %s", owner.getName()));
   }
 
-  @Override
-  public @Nullable AbstractContainerMenu createMenu(int i, Inventory inventory, Player player) {
+  public @Nullable AbstractContainerMenu createMenu(Player player, int i, boolean viewOnly) {
     if (player instanceof ServerPlayer serverPlayer) {
-      return new OpenEnderChestMenu(this, serverPlayer, i);
+      return new OpenEnderChestMenu(this, serverPlayer, i, viewOnly);
     }
     return null;
   }

--- a/internal/v1_21_R1/src/main/java/com/lishid/openinv/internal/v1_21_R1/container/OpenInventory.java
+++ b/internal/v1_21_R1/src/main/java/com/lishid/openinv/internal/v1_21_R1/container/OpenInventory.java
@@ -4,7 +4,6 @@ import com.lishid.openinv.internal.ISpecialPlayerInventory;
 import com.lishid.openinv.internal.InternalOwned;
 import com.lishid.openinv.internal.v1_21_R1.container.bukkit.OpenPlayerInventory;
 import com.lishid.openinv.internal.v1_21_R1.container.menu.OpenInventoryMenu;
-import com.lishid.openinv.internal.v1_21_R1.player.PlayerManager;
 import com.lishid.openinv.internal.v1_21_R1.container.slot.Content;
 import com.lishid.openinv.internal.v1_21_R1.container.slot.ContentCrafting;
 import com.lishid.openinv.internal.v1_21_R1.container.slot.ContentCraftingResult;
@@ -15,6 +14,7 @@ import com.lishid.openinv.internal.v1_21_R1.container.slot.ContentList;
 import com.lishid.openinv.internal.v1_21_R1.container.slot.ContentOffHand;
 import com.lishid.openinv.internal.v1_21_R1.container.slot.ContentViewOnly;
 import com.lishid.openinv.internal.v1_21_R1.container.slot.SlotViewOnly;
+import com.lishid.openinv.internal.v1_21_R1.player.PlayerManager;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
@@ -22,7 +22,6 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
-import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -40,7 +39,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class OpenInventory implements Container, MenuProvider, InternalOwned<ServerPlayer>, ISpecialPlayerInventory {
+public class OpenInventory implements Container, InternalOwned<ServerPlayer>, ISpecialPlayerInventory {
 
   private final List<Content> slots;
   private final int size;
@@ -355,15 +354,9 @@ public class OpenInventory implements Container, MenuProvider, InternalOwned<Ser
     owner.containerMenu.setCarried(ItemStack.EMPTY);
   }
 
-  @Override
-  public Component getDisplayName() {
-    return getTitle(null);
-  }
-
-  @Override
-  public @Nullable AbstractContainerMenu createMenu(int i, Inventory inventory, Player player) {
+  public @Nullable AbstractContainerMenu createMenu(Player player, int i, boolean viewOnly) {
     if (player instanceof ServerPlayer serverPlayer) {
-      return new OpenInventoryMenu(this, serverPlayer, i);
+      return new OpenInventoryMenu(this, serverPlayer, i, viewOnly);
     }
     return null;
   }

--- a/internal/v1_21_R1/src/main/java/com/lishid/openinv/internal/v1_21_R1/container/menu/OpenChestMenu.java
+++ b/internal/v1_21_R1/src/main/java/com/lishid/openinv/internal/v1_21_R1/container/menu/OpenChestMenu.java
@@ -54,13 +54,18 @@ public abstract class OpenChestMenu<T extends Container & ISpecialInventory & In
   private ItemStack remoteCarried = ItemStack.EMPTY;
   private boolean suppressRemoteUpdates;
 
-  protected OpenChestMenu(MenuType<ChestMenu> type, int containerCounter, T container, ServerPlayer viewer) {
+  protected OpenChestMenu(
+      @NotNull MenuType<ChestMenu> type,
+      int containerCounter,
+      @NotNull T container,
+      @NotNull ServerPlayer viewer,
+      boolean viewOnly) {
     super(type, containerCounter);
     this.container = container;
     this.viewer = viewer;
+    this.viewOnly = viewOnly;
     ownContainer = container.getOwnerHandle().equals(viewer);
     topSize = getTopSize(viewer);
-    viewOnly = checkViewOnly();
 
     preSlotSetup();
 
@@ -115,8 +120,6 @@ public abstract class OpenChestMenu<T extends Container & ISpecialInventory & In
       default -> throw new IllegalArgumentException("Inventory size unsupported: " + inventorySize);
     };
   }
-
-  protected abstract boolean checkViewOnly();
 
   protected void preSlotSetup() {}
 

--- a/internal/v1_21_R1/src/main/java/com/lishid/openinv/internal/v1_21_R1/container/menu/OpenEnderChestMenu.java
+++ b/internal/v1_21_R1/src/main/java/com/lishid/openinv/internal/v1_21_R1/container/menu/OpenEnderChestMenu.java
@@ -1,22 +1,20 @@
 package com.lishid.openinv.internal.v1_21_R1.container.menu;
 
 import com.lishid.openinv.internal.v1_21_R1.container.OpenEnderChest;
-import com.lishid.openinv.util.Permissions;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
 
 public class OpenEnderChestMenu extends OpenChestMenu<OpenEnderChest> {
 
-  public OpenEnderChestMenu(OpenEnderChest enderChest, ServerPlayer viewer, int containerId) {
-    super(getChestMenuType(enderChest.getContainerSize()), containerId, enderChest, viewer);
-  }
-
-  @Override
-  protected boolean checkViewOnly() {
-    return !(ownContainer ? Permissions.ENDERCHEST_EDIT_SELF : Permissions.ENDERCHEST_OPEN_OTHER)
-        .hasPermission(viewer.getBukkitEntity());
+  public OpenEnderChestMenu(
+      @NotNull OpenEnderChest enderChest,
+      @NotNull ServerPlayer viewer,
+      int containerId,
+      boolean viewOnly) {
+    super(getChestMenuType(enderChest.getContainerSize()), containerId, enderChest, viewer, viewOnly);
   }
 
   @Override

--- a/internal/v1_21_R1/src/main/java/com/lishid/openinv/internal/v1_21_R1/container/menu/OpenEnderChestMenu.java
+++ b/internal/v1_21_R1/src/main/java/com/lishid/openinv/internal/v1_21_R1/container/menu/OpenEnderChestMenu.java
@@ -15,7 +15,7 @@ public class OpenEnderChestMenu extends OpenChestMenu<OpenEnderChest> {
 
   @Override
   protected boolean checkViewOnly() {
-    return  !(ownContainer ? Permissions.ENDERCHEST_EDIT_SELF : Permissions.ENDERCHEST_OPEN_OTHER)
+    return !(ownContainer ? Permissions.ENDERCHEST_EDIT_SELF : Permissions.ENDERCHEST_OPEN_OTHER)
         .hasPermission(viewer.getBukkitEntity());
   }
 

--- a/internal/v1_21_R1/src/main/java/com/lishid/openinv/internal/v1_21_R1/container/menu/OpenInventoryMenu.java
+++ b/internal/v1_21_R1/src/main/java/com/lishid/openinv/internal/v1_21_R1/container/menu/OpenInventoryMenu.java
@@ -26,8 +26,8 @@ public class OpenInventoryMenu extends OpenChestMenu<OpenInventory> {
 
   private int offset;
 
-  public OpenInventoryMenu(OpenInventory inventory, ServerPlayer viewer, int i) {
-    super(getMenuType(inventory, viewer), i, inventory, viewer);
+  public OpenInventoryMenu(OpenInventory inventory, ServerPlayer viewer, int i, boolean viewOnly) {
+    super(getMenuType(inventory, viewer), i, inventory, viewer, viewOnly);
   }
 
   private static MenuType<ChestMenu> getMenuType(OpenInventory inventory, ServerPlayer viewer) {
@@ -95,12 +95,6 @@ public class OpenInventoryMenu extends OpenChestMenu<OpenInventory> {
     }
 
     return slot;
-  }
-
-  @Override
-  protected boolean checkViewOnly() {
-    return !(ownContainer ? Permissions.INVENTORY_EDIT_SELF : Permissions.INVENTORY_EDIT_OTHER)
-        .hasPermission(viewer.getBukkitEntity());
   }
 
   @Override

--- a/plugin/src/main/java/com/lishid/openinv/command/OpenInvCommand.java
+++ b/plugin/src/main/java/com/lishid/openinv/command/OpenInvCommand.java
@@ -18,6 +18,7 @@ package com.lishid.openinv.command;
 
 import com.lishid.openinv.OpenInv;
 import com.lishid.openinv.internal.ISpecialInventory;
+import com.lishid.openinv.util.AccessEqualMode;
 import com.lishid.openinv.util.InventoryManager;
 import com.lishid.openinv.util.Permissions;
 import com.lishid.openinv.util.PlayerLoader;
@@ -197,7 +198,7 @@ public class OpenInvCommand implements TabExecutor {
             for (int level = 4; level > 0; --level) {
                 String permission = "openinv.access.level." + level;
                 if (onlineTarget.hasPermission(permission)
-                        && !player.hasPermission(permission)) {
+                        && (!player.hasPermission(permission) || config.getAccessEqualMode() == AccessEqualMode.DENY)) {
                     lang.sendMessage(
                         player,
                         "messages.error.permissionExempt",

--- a/plugin/src/main/java/com/lishid/openinv/util/AccessEqualMode.java
+++ b/plugin/src/main/java/com/lishid/openinv/util/AccessEqualMode.java
@@ -7,15 +7,16 @@ import java.util.Locale;
 
 public enum AccessEqualMode {
 
-  DENY, ALLOW;
+  DENY, ALLOW, VIEW;
 
   public static @NotNull AccessEqualMode of(@Nullable String value) {
     if (value == null) {
-      return ALLOW;
+      return VIEW;
     }
     return switch (value.toLowerCase(Locale.ENGLISH)) {
       case "deny", "false" -> DENY;
-      default -> ALLOW;
+      case "allow", "true" -> ALLOW;
+      default -> VIEW;
     };
   }
 

--- a/plugin/src/main/java/com/lishid/openinv/util/AccessEqualMode.java
+++ b/plugin/src/main/java/com/lishid/openinv/util/AccessEqualMode.java
@@ -1,0 +1,22 @@
+package com.lishid.openinv.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Locale;
+
+public enum AccessEqualMode {
+
+  DENY, ALLOW;
+
+  public static @NotNull AccessEqualMode of(@Nullable String value) {
+    if (value == null) {
+      return ALLOW;
+    }
+    return switch (value.toLowerCase(Locale.ENGLISH)) {
+      case "deny", "false" -> DENY;
+      default -> ALLOW;
+    };
+  }
+
+}

--- a/plugin/src/main/java/com/lishid/openinv/util/InternalAccessor.java
+++ b/plugin/src/main/java/com/lishid/openinv/util/InternalAccessor.java
@@ -163,11 +163,11 @@ public class InternalAccessor {
         return internal.getAnySilentContainer();
     }
 
-    public @Nullable InventoryView openInventory(@NotNull Player player, @NotNull ISpecialInventory inventory) {
+    public @Nullable InventoryView openInventory(@NotNull Player player, @NotNull ISpecialInventory inventory, boolean viewOnly) {
         if (internal == null) {
             throw new IllegalStateException(String.format("Unsupported server version %s!", BukkitVersions.MINECRAFT));
         }
-        return internal.getPlayerManager().openInventory(player, inventory);
+        return internal.getPlayerManager().openInventory(player, inventory, viewOnly);
     }
 
     /**

--- a/plugin/src/main/java/com/lishid/openinv/util/config/Config.java
+++ b/plugin/src/main/java/com/lishid/openinv/util/config/Config.java
@@ -1,12 +1,15 @@
 package com.lishid.openinv.util.config;
 
+import com.lishid.openinv.util.AccessEqualMode;
 import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.MemoryConfiguration;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class Config {
 
   private @NotNull Configuration root;
+  private @Nullable AccessEqualMode accessEqualMode;
 
   public Config() {
     root = new MemoryConfiguration();
@@ -14,6 +17,7 @@ public class Config {
 
   public void reload(@NotNull Configuration configuration) {
     root = configuration;
+    accessEqualMode = null;
   }
 
   public boolean isSaveDisabled() {
@@ -26,6 +30,14 @@ public class Config {
 
   public boolean doesNoArgsOpenSelf() {
     return root.getBoolean("settings.command.open.no-args-opens-self", false);
+  }
+
+  public @NotNull AccessEqualMode getAccessEqualMode() {
+    if (accessEqualMode == null) {
+      accessEqualMode = AccessEqualMode.of(root.getString("settings.equal-access"));
+    }
+
+    return accessEqualMode;
   }
 
 }

--- a/plugin/src/main/java/com/lishid/openinv/util/config/ConfigUpdater.java
+++ b/plugin/src/main/java/com/lishid/openinv/util/config/ConfigUpdater.java
@@ -61,9 +61,18 @@ public record ConfigUpdater(@NotNull Plugin plugin) {
         if (version < 7) {
             updateConfig6To7();
         }
+        if (version < 8) {
+            updateConfig7To8();
+        }
 
         plugin.saveConfig();
         plugin.getLogger().info("Configuration update complete!");
+    }
+
+    private void updateConfig7To8() {
+        FileConfiguration config = plugin.getConfig();
+        config.set("settings.equal-access", "allow");
+        config.set("config-version", 8);
     }
 
     private void updateConfig6To7() {

--- a/plugin/src/main/java/com/lishid/openinv/util/config/ConfigUpdater.java
+++ b/plugin/src/main/java/com/lishid/openinv/util/config/ConfigUpdater.java
@@ -71,7 +71,7 @@ public record ConfigUpdater(@NotNull Plugin plugin) {
 
     private void updateConfig7To8() {
         FileConfiguration config = plugin.getConfig();
-        config.set("settings.equal-access", "allow");
+        config.set("settings.equal-access", "view");
         config.set("config-version", 8);
     }
 

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -1,5 +1,6 @@
-config-version: 7
+config-version: 8
 settings:
+  equal-access: allow
   command:
     open:
       no-args-opens-self: false

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -1,6 +1,6 @@
 config-version: 8
 settings:
-  equal-access: allow
+  equal-access: view
   command:
     open:
       no-args-opens-self: false


### PR DESCRIPTION
Defaults to previous behavior of allowing.

Does not currently offer view-only mode - I'm rushing to cut a release, and communicating to the internals that the inventory is to be view-only is complicated without undoing some of the work I put in to improving the project structure.

Closes #228 