### PR TITLE
Add support for 1.21.3

### DIFF
--- a/resource-pack/pack.mcmeta
+++ b/resource-pack/pack.mcmeta
@@ -1,6 +1,7 @@
 {
   "pack": {
     "description": "Improve OpenInv's legibility",
-    "pack_format": 34
+    "pack_format": 42,
+    "supported_formats": [34, 42]
   }
 }


### PR DESCRIPTION
This change updates the pack.mcmeta to support `1.21.3`, but also adds support for `1.21`–`1.21.1` since there shouldn't be anything that conflicts between the two versions for this resource pack.