### PR TITLE
Improve equal access

### DIFF
--- a/plugin/src/main/java/com/lishid/openinv/OpenInv.java
+++ b/plugin/src/main/java/com/lishid/openinv/OpenInv.java
@@ -255,30 +255,32 @@ public class OpenInv extends JavaPlugin implements IOpenInv {
 
         boolean viewOnly = edit != null && !edit.hasPermission(player);
 
-        if (!ownContainer && !viewOnly) {
-            for (int level = 4; level > 0; --level) {
-                String permission = "openinv.access.level." + level;
-                // If the target doesn't have this access level...
-                if (!target.hasPermission(permission)) {
-                    // If the viewer does have the access level, all good.
-                    if (player.hasPermission(permission)) {
-                        break;
-                    }
-                    // Otherwise check next access level.
-                    continue;
-                }
+        if (ownContainer || viewOnly && config.getAccessEqualMode() != AccessEqualMode.DENY) {
+            this.accessor.openInventory(player, inventory, viewOnly);
+        }
 
-                // If the player doesn't have an equal access level or equal access is a denial, deny.
-                if (!player.hasPermission(permission) || config.getAccessEqualMode() == AccessEqualMode.DENY) {
-                    return null;
+        for (int level = 4; level > 0; --level) {
+            String permission = "openinv.access.level." + level;
+            // If the target doesn't have this access level...
+            if (!target.hasPermission(permission)) {
+                // If the viewer does have the access level, all good.
+                if (player.hasPermission(permission)) {
+                    break;
                 }
-
-                // Since this is a tie, setting decides view state.
-                if (config.getAccessEqualMode() == AccessEqualMode.VIEW) {
-                    viewOnly = true;
-                }
-                break;
+                // Otherwise check next access level.
+                continue;
             }
+
+            // If the viewer doesn't have an equal access level or equal access is a denial, deny.
+            if (!player.hasPermission(permission) || config.getAccessEqualMode() == AccessEqualMode.DENY) {
+                return null;
+            }
+
+            // Since this is a tie, setting decides view state.
+            if (config.getAccessEqualMode() == AccessEqualMode.VIEW) {
+                viewOnly = true;
+            }
+            break;
         }
 
         return this.accessor.openInventory(player, inventory, viewOnly);

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -1,6 +1,6 @@
 config-version: 8
 settings:
-  equal-access: view
+  equal-access: allow
   command:
     open:
       no-args-opens-self: false


### PR DESCRIPTION
* Respect deny mode for equals if viewer cannot edit
* Revert default mode to allow equal access
  * Several people have gotten confused by the view-only default for equals - it is not intuitive, and OI generally Just Works(TM) with no config. This will make OI more functional out of the box on basic servers with no permissions.

I have verified that access levels work correctly (assuming target is online; still no offline perms support).
Closes #268 