### PR TITLE
Fix off-hand update relying on Spigot method

### DIFF
--- a/internal/v1_21_R2/src/main/java/com/lishid/openinv/internal/v1_21_R2/container/slot/ContentOffHand.java
+++ b/internal/v1_21_R2/src/main/java/com/lishid/openinv/internal/v1_21_R2/container/slot/ContentOffHand.java
@@ -1,8 +1,10 @@
 package com.lishid.openinv.internal.v1_21_R2.container.slot;
 
+import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.inventory.Slot;
 import org.bukkit.event.inventory.InventoryType;
 import org.jetbrains.annotations.NotNull;
@@ -37,7 +39,12 @@ public class ContentOffHand extends ContentEquipment {
         if (holder.connection != null
             && !holder.connection.isDisconnected()
             && holder.containerMenu != holder.inventoryMenu) {
-          holder.resendItemInHands();
+          holder.connection.send(
+              new ClientboundContainerSetSlotPacket(
+                  holder.inventoryMenu.containerId,
+                  holder.inventoryMenu.incrementStateId(),
+                  InventoryMenu.SHIELD_SLOT,
+                  holder.getOffhandItem()));
         }
       }
     };

--- a/internal/v1_21_R3/src/main/java/com/lishid/openinv/internal/v1_21_R3/container/slot/ContentOffHand.java
+++ b/internal/v1_21_R3/src/main/java/com/lishid/openinv/internal/v1_21_R3/container/slot/ContentOffHand.java
@@ -1,8 +1,10 @@
 package com.lishid.openinv.internal.v1_21_R3.container.slot;
 
+import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.inventory.InventoryMenu;
 import net.minecraft.world.inventory.Slot;
 import org.bukkit.event.inventory.InventoryType;
 import org.jetbrains.annotations.NotNull;
@@ -37,7 +39,12 @@ public class ContentOffHand extends ContentEquipment {
         if (holder.connection != null
             && !holder.connection.isDisconnected()
             && holder.containerMenu != holder.inventoryMenu) {
-          holder.resendItemInHands();
+          holder.connection.send(
+              new ClientboundContainerSetSlotPacket(
+                  holder.inventoryMenu.containerId,
+                  holder.inventoryMenu.incrementStateId(),
+                  InventoryMenu.SHIELD_SLOT,
+                  holder.getOffhandItem()));
         }
       }
     };


### PR DESCRIPTION
Unfortunately, as I thought, the reason I used the method in question was that the synchronizer is not visible. This means that we do now have to manually send an update packet ourselves, which is much more likely to break between versions.

The good news is that updating the off hand now does not also update the main hand, which, while it wasn't a huge deal, was an unnecessary additional packet.

Closes #276