### PR TITLE
Remap reflection

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,4 +4,10 @@ plugins {
 
 repositories {
   gradlePluginPortal()
+  mavenCentral()
+}
+
+dependencies {
+  val libs = project.extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
+  implementation(variantOf(libs.findLibrary("specialsource").orElseThrow()) { classifier("shaded") })
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("../gradle/libs.versions.toml"))
+    }
+  }
+}

--- a/buildSrc/src/main/kotlin/com/github/jikoo/openinv/SpigotReobf.kt
+++ b/buildSrc/src/main/kotlin/com/github/jikoo/openinv/SpigotReobf.kt
@@ -2,13 +2,11 @@ package com.github.jikoo.openinv
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.attributes.Bundling
 import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.attributes.Usage
 import org.gradle.jvm.tasks.Jar
-import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 import java.nio.file.Paths
@@ -16,7 +14,6 @@ import java.nio.file.Paths
 class SpigotReobf: Plugin<Project> {
 
   companion object {
-    internal const val DEP_CONFIG = "spigotReobfDep"
     const val ARTIFACT_CONFIG = "reobf"
   }
 
@@ -38,13 +35,6 @@ class SpigotReobf: Plugin<Project> {
       inputFile.convention(target.tasks.named<Jar>("shadowJar").get().archiveFile)
       spigotVersion.convention(spigotExt.version)
       getMavenLocal().set(Paths.get(mvnLocal.url).toFile())
-    }
-
-    // Create a separate configuration for SpecialSource to make it easier to locate.
-    val reobfDeps = target.configurations.create(DEP_CONFIG)
-    target.dependencies {
-      val libs = target.extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
-      reobfDeps(variantOf(libs.findLibrary("specialsource").orElseThrow()) { classifier("shaded") })
     }
 
     // Set up configuration for producing reobf jar.

--- a/buildSrc/src/main/kotlin/com/github/jikoo/openinv/SpigotReobfTask.kt
+++ b/buildSrc/src/main/kotlin/com/github/jikoo/openinv/SpigotReobfTask.kt
@@ -1,19 +1,18 @@
 package com.github.jikoo.openinv
 
+import com.github.jikoo.openinv.specialsource.ReflectionJarMapping
+import net.md_5.specialsource.*
+import net.md_5.specialsource.provider.JarProvider
+import net.md_5.specialsource.provider.JointProvider
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.bundling.Jar
-import org.gradle.process.internal.ExecActionFactory
 import java.io.File
-import javax.inject.Inject
 
-abstract class SpigotReobfTask @Inject constructor(
-  private var execActionFactory: ExecActionFactory
-) : Jar() {
+abstract class SpigotReobfTask: org.gradle.api.tasks.bundling.Jar() {
 
   @get:Input
   val spigotVersion: Property<String> = objectFactory.property(String::class.java)
@@ -23,12 +22,6 @@ abstract class SpigotReobfTask @Inject constructor(
 
   @get:Input
   val intermediaryClassifier: Property<String> = objectFactory.property(String::class.java).convention("mojang-mapped")
-
-  private val specialSource: Property<File> = objectFactory.property(File::class.java).convention(project.provider {
-    // Grab SpecialSource location from dependency declaration.
-    project.configurations.named(SpigotReobf.DEP_CONFIG).get().incoming.artifacts.artifacts
-      .first { it.id.componentIdentifier.toString().startsWith("net.md-5:SpecialSource:") }.file
-  })
 
   private val mavenLocal: Property<File> = objectFactory.property(File::class.java)
 
@@ -43,7 +36,6 @@ abstract class SpigotReobfTask @Inject constructor(
     val obfPath = inFile.resolveSibling(inFile.name.replace(".jar", "-${intermediaryClassifier.get()}.jar"))
 
     // https://www.spigotmc.org/threads/510208/#post-4184317
-    val specialSourceFile = specialSource.get()
     val repo = mavenLocal.get()
     val spigotDir = repo.resolve("org/spigotmc/spigot/$spigotVer/")
     val mappingDir = repo.resolve("org/spigotmc/minecraft-server/$spigotVer/")
@@ -51,27 +43,40 @@ abstract class SpigotReobfTask @Inject constructor(
     // Remap original Mojang-mapped jar to obfuscated intermediary
     val mojangServer = spigotDir.resolve("spigot-$spigotVer-remapped-mojang.jar")
     val mojangMappings = mappingDir.resolve("minecraft-server-$spigotVer-maps-mojang.txt")
-    remapPartial(specialSourceFile, mojangServer, mojangMappings, inFile, obfPath, true)
+    remapPartial(mojangServer, mojangMappings, inFile, obfPath, true)
 
     // Remap obfuscated intermediary jar to Spigot and replace original
     val obfServer = spigotDir.resolve("spigot-$spigotVer-remapped-obf.jar")
     val spigotMappings = mappingDir.resolve("minecraft-server-$spigotVer-maps-spigot.csrg")
-    remapPartial(specialSourceFile, obfServer, spigotMappings, obfPath, archiveFile.get().asFile, false)
+    remapPartial(obfServer, spigotMappings, obfPath, archiveFile.get().asFile, false)
   }
 
-  private fun remapPartial(specialSourceFile: File, serverJar: File, mapping: File, input: File, output: File, reverse: Boolean) {
-    // May need a direct dependency on SpecialSource later to customize behavior.
-    val exec = execActionFactory.newJavaExecAction()
-    exec.classpath(specialSourceFile, serverJar)
-    exec.mainClass.value("net.md_5.specialsource.SpecialSource")
-    exec.args(
-      "--live",
-      "-i", input.path,
-      "-o", output.path,
-      "-m", "$mapping",
-      if (reverse) "--reverse" else ""
-    )
-    exec.execute().rethrowFailure()
+  private fun remapPartial(server: File, mapping: File, input: File, output: File, reverse: Boolean) {
+    val jarMapping = JarMapping()
+    jarMapping.loadMappings(mapping.path, reverse, false, null, null)
+
+    val inheritance = JointProvider()
+    jarMapping.setFallbackInheritanceProvider(inheritance)
+
+    // Equivalent of --live with server jar on classpath.
+    val serverJar = Jar.init(server)
+    inheritance.add(JarProvider(serverJar))
+
+    val inputJar = Jar.init(input)
+    inheritance.add(JarProvider(inputJar))
+
+    // Remap reflective access.
+    val reflectionMapping = ReflectionJarMapping()
+    reflectionMapping.loadMappings(mapping.path, reverse, false, null, null)
+    val inheritanceMap = InheritanceMap()
+    inheritanceMap.generate(inheritance, reflectionMapping.classes.values)
+    val preprocessor = RemapperProcessor(inheritanceMap, reflectionMapping, null)
+
+    val remapper = JarRemapper(preprocessor, jarMapping, null)
+    remapper.remapJar(inputJar, output)
+
+    serverJar.close()
+    inputJar.close()
   }
 
   @Internal

--- a/buildSrc/src/main/kotlin/com/github/jikoo/openinv/SpigotReobfTask.kt
+++ b/buildSrc/src/main/kotlin/com/github/jikoo/openinv/SpigotReobfTask.kt
@@ -1,7 +1,9 @@
 package com.github.jikoo.openinv
 
 import com.github.jikoo.openinv.specialsource.ReflectionJarMapping
-import net.md_5.specialsource.*
+import com.github.jikoo.openinv.specialsource.ReflectionPreprocessor
+import net.md_5.specialsource.Jar
+import net.md_5.specialsource.JarRemapper
 import net.md_5.specialsource.provider.JarProvider
 import net.md_5.specialsource.provider.JointProvider
 import org.gradle.api.file.RegularFileProperty
@@ -52,7 +54,7 @@ abstract class SpigotReobfTask: org.gradle.api.tasks.bundling.Jar() {
   }
 
   private fun remapPartial(server: File, mapping: File, input: File, output: File, reverse: Boolean) {
-    val jarMapping = JarMapping()
+    val jarMapping = ReflectionJarMapping()
     jarMapping.loadMappings(mapping.path, reverse, false, null, null)
 
     val inheritance = JointProvider()
@@ -66,11 +68,7 @@ abstract class SpigotReobfTask: org.gradle.api.tasks.bundling.Jar() {
     inheritance.add(JarProvider(inputJar))
 
     // Remap reflective access.
-    val reflectionMapping = ReflectionJarMapping()
-    reflectionMapping.loadMappings(mapping.path, reverse, false, null, null)
-    val inheritanceMap = InheritanceMap()
-    inheritanceMap.generate(inheritance, reflectionMapping.classes.values)
-    val preprocessor = RemapperProcessor(inheritanceMap, reflectionMapping, null)
+    val preprocessor = ReflectionPreprocessor(jarMapping)
 
     val remapper = JarRemapper(preprocessor, jarMapping, null)
     remapper.remapJar(inputJar, output)

--- a/buildSrc/src/main/kotlin/com/github/jikoo/openinv/specialsource/ReflectionJarMapping.kt
+++ b/buildSrc/src/main/kotlin/com/github/jikoo/openinv/specialsource/ReflectionJarMapping.kt
@@ -1,0 +1,474 @@
+package com.github.jikoo.openinv.specialsource
+
+import net.md_5.specialsource.JarMapping
+import net.md_5.specialsource.ProgressMeter
+import net.md_5.specialsource.transformer.MappingTransformer
+import net.md_5.specialsource.transformer.MavenShade
+import org.objectweb.asm.commons.Remapper
+import java.io.BufferedReader
+import java.io.IOException
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+
+class ReflectionJarMapping: JarMapping() {
+
+  private var currentClass: String? = null
+
+  override fun loadMappings(
+    reader: BufferedReader,
+    inputTransformer: MappingTransformer?,
+    outputTransformer: MappingTransformer?,
+    reverse: Boolean
+  ) {
+    val inTransformer = inputTransformer ?: MavenShade.IDENTITY
+    val outTransformer = outputTransformer ?: MavenShade.IDENTITY
+
+    val lines = ArrayList<String>()
+
+    reader.lines().forEach {
+      var line = it
+      val commentIndex = line.indexOf('#')
+      if (commentIndex != -1) {
+        line = line.substring(0, commentIndex)
+      }
+
+      if (line.isNotEmpty()) {
+        lines.add(line)
+      }
+    }
+
+    val meter = ProgressMeter(lines.size * 2, "Loading mappings... %2.0f%%")
+    val clsMap: MutableMap<String, String> = HashMap()
+    val prgMap: MutableMap<String, String> = HashMap()
+
+    val proguard = " -> ".toRegex()
+    for (l in lines) {
+      if (l.endsWith(":")) {
+        val parts = l.split(proguard).dropLastWhile { it.isEmpty() }.toTypedArray()
+        val orig = parts[0].replace('.', '/')
+        val obf = parts[1].substring(0, parts[1].length - 1).replace('.', '/')
+        clsMap[obf] = orig
+        prgMap[orig] = obf
+      } else if (l.contains(":")) {
+        if (!l.startsWith("CL:")) {
+          continue
+        }
+
+        val tokens = l.split(" ".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        clsMap[tokens[0]] = tokens[1]
+      } else {
+        if (l.startsWith("\t")) {
+          continue
+        }
+
+        val tokens = l.split(" ".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        if (tokens.size == 2) {
+          clsMap[tokens[0]] = tokens[1]
+        }
+      }
+
+      meter.makeProgress()
+    }
+
+    val reverseMapper: Remapper = object : Remapper() {
+      override fun map(cls: String): String {
+        return clsMap.getOrDefault(cls, cls)
+      }
+    }
+
+    for (l in lines) {
+      if (!l.startsWith("tsrg2")) {
+        if (l.contains(" -> ")) {
+          this.parseProguardLine(l, inTransformer, outTransformer, reverse, reverseMapper, prgMap)
+        } else if (l.contains(":")) {
+          this.parseSrgLine(l, inTransformer, outTransformer, reverse)
+        } else {
+          this.parseCsrgLine(l, inTransformer, outTransformer, reverse, reverseMapper)
+        }
+
+        meter.makeProgress()
+      }
+    }
+
+    this.currentClass = null
+  }
+
+  class ProguardUtil {
+    companion object {
+      val MEMBER_PATTERN: Pattern = Pattern.compile("(?:\\d+:\\d+:)?(.*?) (.*?) -> (.*)")
+
+      fun csrgDesc(data: Map<String, String>, args: String, ret: String): String {
+        val parts = args.substring(1, args.length - 1).split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        val desc = StringBuilder("(")
+        for (part in parts) {
+          if (part.isEmpty()) {
+            continue
+          }
+          desc.append(toJVMType(data, part))
+        }
+        desc.append(")")
+        desc.append(toJVMType(data, ret))
+        return desc.toString()
+      }
+
+      fun toJVMType(data: Map<String, String>, type: String): String {
+        when (type) {
+          "byte" -> return "B"
+          "char" -> return "C"
+          "double" -> return "D"
+          "float" -> return "F"
+          "int" -> return "I"
+          "long" -> return "J"
+          "short" -> return "S"
+          "boolean" -> return "Z"
+          "void" -> return "V"
+          else -> {
+            if (type.endsWith("[]")) {
+              return "[" + toJVMType(data, type.substring(0, type.length - 2))
+            }
+            val clazzType = type.replace('.', '/')
+            val mappedType = data[clazzType]
+
+            return "L" + (mappedType ?: clazzType) + ";"
+          }
+        }
+      }
+    }
+
+  }
+
+  @Throws(IOException::class)
+  private fun parseProguardLine(
+    originalLine: String,
+    inputTransformer: MappingTransformer,
+    outputTransformer: MappingTransformer,
+    reverse: Boolean,
+    reverseMap: Remapper,
+    prgMap: Map<String, String>
+  ) {
+    //Tsrg format, identical to Csrg, except the field and method lines start with \t and should use the last class the was parsed.
+    var line = originalLine
+    if (line.startsWith("    ")) {
+      if (this.currentClass == null) {
+        throw IOException("Invalid proguard file, tsrg field/method line before class line: $line")
+      }
+      line = line.trim { it <= ' ' }
+    }
+
+    if (line.endsWith(":")) {
+      val parts = line.split(" -> ".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+      val orig = parts[0].replace('.', '/')
+      val obf = parts[1].substring(0, parts[1].length - 1).replace('.', '/')
+
+      val oldClassName = inputTransformer.transformClassName(obf)
+      val newClassName = outputTransformer.transformClassName(orig)
+
+      if (oldClassName.endsWith("/")) {
+        // Special case: mapping an entire hierarchy of classes
+        if (reverse) {
+          packages[newClassName] = oldClassName.substring(0, oldClassName.length - 1)
+        } else {
+          packages[oldClassName.substring(0, oldClassName.length - 1)] = newClassName
+        }
+      } else {
+        if (reverse) {
+          classes[newClassName] = oldClassName
+        } else {
+          classes[oldClassName] = newClassName
+        }
+        currentClass = obf
+      }
+    } else {
+      val matcher: Matcher = ProguardUtil.MEMBER_PATTERN.matcher(line)
+      matcher.find()
+
+      val obfName: String = matcher.group(3)
+      val nameDesc: String = matcher.group(2)
+      if (nameDesc.contains("(")) {
+        val desc = ProguardUtil.csrgDesc(prgMap, nameDesc.substring(nameDesc.indexOf('(')), matcher.group(1))
+        val newName = nameDesc.substring(0, nameDesc.indexOf('('))
+
+        var oldClassName = inputTransformer.transformClassName(currentClass)
+        var oldMethodName = inputTransformer.transformMethodName(currentClass, obfName, desc)
+        var oldMethodDescriptor = inputTransformer.transformMethodDescriptor(desc)
+        var newMethodName = outputTransformer.transformMethodName(currentClass, newName, desc)
+
+        if (reverse) {
+          val newClassName = reverseMap.map(oldClassName)
+          oldClassName = newClassName
+          oldMethodDescriptor = reverseMap.mapMethodDesc(oldMethodDescriptor)
+
+          val temp = newMethodName
+          newMethodName = oldMethodName
+          oldMethodName = temp
+        }
+
+        methods["$oldClassName/$oldMethodName $oldMethodDescriptor"] = newMethodName
+      } else {
+        var oldClassName = inputTransformer.transformClassName(currentClass)
+        var oldFieldName = inputTransformer.transformFieldName(currentClass, obfName)
+        var newFieldName = outputTransformer.transformFieldName(currentClass, nameDesc)
+
+        if (reverse) {
+          val newClassName = reverseMap.map(oldClassName)
+          oldClassName = newClassName
+
+          val temp = newFieldName
+          newFieldName = oldFieldName
+          oldFieldName = temp
+        }
+
+        fields["$oldClassName/$oldFieldName"] = newFieldName
+      }
+    }
+  }
+
+  /**
+   * Parse a 'csrg' mapping format line and populate the data structures
+   */
+  @Throws(IOException::class)
+  private fun parseCsrgLine(
+    originalLine: String,
+    inputTransformer: MappingTransformer,
+    outputTransformer: MappingTransformer,
+    reverse: Boolean,
+    reverseMap: Remapper
+  ) {
+    //Tsrg format, identical to Csrg, except the field and method lines start with \t and should use the last class the was parsed.
+    var line = originalLine
+    if (line.startsWith("\t\t")) {
+      // Two tabs means the format is Tsrgv2 with parameters and extra data that isn't needed.
+      return
+    }
+    if (line.startsWith("\t")) {
+      if (this.currentClass == null) {
+        throw IOException("Invalid tsrg file, tsrg field/method line before class line: $line")
+      }
+      line = currentClass + " " + line.substring(1)
+    }
+
+    val tokens = line.split(" ".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+
+    if (tokens.size == 2) {
+      var oldClassName = inputTransformer.transformClassName(tokens[0])
+      var newClassName = outputTransformer.transformClassName(tokens[1])
+
+      if (oldClassName.endsWith("/")) {
+        // package names always either 1) suffixed with '/', or 2) equal to '.' to signify default package
+
+        if (newClassName != "." && !newClassName.endsWith("/")) {
+          newClassName += "/"
+        }
+
+        if (oldClassName != "." && !oldClassName.endsWith("/")) {
+          oldClassName += "/"
+        }
+
+        // Special case: mapping an entire hierarchy of classes
+        if (reverse) {
+          packages[newClassName] = oldClassName
+        } else {
+          packages[oldClassName] = newClassName
+        }
+      } else {
+        if (reverse) {
+          classes[newClassName] = oldClassName
+        } else {
+          classes[oldClassName] = newClassName
+        }
+        currentClass = tokens[0]
+      }
+    } else if (tokens.size == 3) {
+      var oldClassName = inputTransformer.transformClassName(tokens[0])
+      var oldFieldName = inputTransformer.transformFieldName(tokens[0], tokens[1])
+      var newFieldName = outputTransformer.transformFieldName(tokens[0], tokens[2])
+
+      if (reverse) {
+        val newClassName = reverseMap.map(oldClassName)
+        oldClassName = newClassName
+
+        val temp = newFieldName
+        newFieldName = oldFieldName
+        oldFieldName = temp
+      }
+
+      fields["$oldClassName/$oldFieldName"] = newFieldName
+    } else if (tokens.size == 4) {
+      var oldClassName = inputTransformer.transformClassName(tokens[0])
+      var oldMethodName = inputTransformer.transformMethodName(tokens[0], tokens[1], tokens[2])
+      var oldMethodDescriptor = inputTransformer.transformMethodDescriptor(tokens[2])
+      var newMethodName = outputTransformer.transformMethodName(tokens[0], tokens[3], tokens[2])
+
+      if (reverse) {
+        val newClassName = reverseMap.map(oldClassName)
+        oldClassName = newClassName
+        oldMethodDescriptor = reverseMap.mapMethodDesc(oldMethodDescriptor)
+
+        val temp = newMethodName
+        newMethodName = oldMethodName
+        oldMethodName = temp
+      }
+
+      methods["$oldClassName/$oldMethodName $oldMethodDescriptor"] = newMethodName
+    } else {
+      throw IOException("Invalid csrg file line, token count " + tokens.size + " unexpected in " + line)
+    }
+  }
+
+  /**
+   * Parse a standard 'srg' mapping format line and populate the data
+   * structures
+   */
+  @Throws(IOException::class)
+  private fun parseSrgLine(
+    line: String,
+    inputTransformer: MappingTransformer,
+    outputTransformer: MappingTransformer,
+    reverse: Boolean
+  ) {
+    val tokens = line.split(" ".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+    val kind = tokens[0]
+
+    if (kind == "CL:") {
+      var oldClassName = inputTransformer.transformClassName(tokens[1])
+      var newClassName = outputTransformer.transformClassName(tokens[2])
+
+      if (reverse) {
+        val temp = newClassName
+        newClassName = oldClassName
+        oldClassName = temp
+      }
+
+      require(!(classes.containsKey(oldClassName) && newClassName != classes[oldClassName])) {
+        ("Duplicate class mapping: " + oldClassName + " -> " + newClassName
+            + " but already mapped to " + classes[oldClassName] + " in line=" + line)
+      }
+
+      if (oldClassName.endsWith("/*") && newClassName.endsWith("/*")) {
+        // extension for remapping class name prefixes
+        oldClassName = oldClassName.substring(0, oldClassName.length - 1)
+        newClassName = newClassName.substring(0, newClassName.length - 1)
+
+        packages[oldClassName] = newClassName
+      } else {
+        classes[oldClassName] = newClassName
+        currentClass = tokens[0]
+      }
+    } else if (kind == "PK:") {
+      var oldPackageName = inputTransformer.transformClassName(tokens[1])
+      var newPackageName = outputTransformer.transformClassName(tokens[2])
+
+      if (reverse) {
+        val temp = newPackageName
+        newPackageName = oldPackageName
+        oldPackageName = temp
+      }
+
+      // package names always either 1) suffixed with '/', or 2) equal to '.' to signify default package
+      if (newPackageName != "." && !newPackageName.endsWith("/")) {
+        newPackageName += "/"
+      }
+
+      if (oldPackageName != "." && !oldPackageName.endsWith("/")) {
+        oldPackageName += "/"
+      }
+
+      require(!(packages.containsKey(oldPackageName) && newPackageName != packages[oldPackageName])) {
+        ("Duplicate package mapping: " + oldPackageName + " ->" + newPackageName
+            + " but already mapped to " + packages[oldPackageName] + " in line=" + line)
+      }
+
+      packages[oldPackageName] = newPackageName
+    } else if (kind == "FD:") {
+      val oldFull = tokens[1]
+      val newFull = tokens[2]
+
+      // Split the qualified field names into their classes and actual names
+      val splitOld = oldFull.lastIndexOf('/')
+      val splitNew = newFull.lastIndexOf('/')
+      require(!(splitOld == -1 || splitNew == -1)) {
+        ("Field name is invalid, not fully-qualified: " + oldFull
+            + " -> " + newFull + " in line=" + line)
+      }
+
+      var oldClassName = inputTransformer.transformClassName(oldFull.substring(0, splitOld))
+      var oldFieldName =
+        inputTransformer.transformFieldName(oldFull.substring(0, splitOld), oldFull.substring(splitOld + 1))
+      val newClassName = outputTransformer.transformClassName(
+        newFull.substring(
+          0,
+          splitNew
+        )
+      )
+      var newFieldName =
+        outputTransformer.transformFieldName(oldFull.substring(0, splitOld), newFull.substring(splitNew + 1))
+
+      if (reverse) {
+        oldClassName = newClassName
+
+        val temp = newFieldName
+        newFieldName = oldFieldName
+        oldFieldName = temp
+      }
+
+      val oldEntry = "$oldClassName/$oldFieldName"
+      require(!(fields.containsKey(oldEntry) && newFieldName != fields[oldEntry])) {
+        ("Duplicate field mapping: " + oldEntry + " ->" + newFieldName
+            + " but already mapped to " + fields[oldEntry] + " in line=" + line)
+      }
+
+      fields[oldEntry] = newFieldName
+    } else if (kind == "MD:") {
+      val oldFull = tokens[1]
+      val newFull = tokens[3]
+
+      // Split the qualified field names into their classes and actual names
+      val splitOld = oldFull.lastIndexOf('/')
+      val splitNew = newFull.lastIndexOf('/')
+      require(!(splitOld == -1 || splitNew == -1)) {
+        ("Field name is invalid, not fully-qualified: " + oldFull
+            + " -> " + newFull + " in line=" + line)
+      }
+
+      var oldClassName = inputTransformer.transformClassName(oldFull.substring(0, splitOld))
+      var oldMethodName = inputTransformer.transformMethodName(
+        oldFull.substring(0, splitOld), oldFull.substring(splitOld + 1),
+        tokens[2]
+      )
+      var oldMethodDescriptor = inputTransformer.transformMethodDescriptor(tokens[2])
+      val newClassName = outputTransformer.transformClassName(
+        newFull.substring(
+          0,
+          splitNew
+        )
+      )
+      var newMethodName = outputTransformer.transformMethodName(
+        oldFull.substring(0, splitOld), newFull.substring(splitNew + 1),
+        tokens[2]
+      )
+      val newMethodDescriptor =
+        outputTransformer.transformMethodDescriptor(tokens[4])
+
+      if (reverse) {
+        oldClassName = newClassName
+        oldMethodDescriptor = newMethodDescriptor
+
+        val temp = newMethodName
+        newMethodName = oldMethodName
+        oldMethodName = temp
+      }
+
+      val oldEntry = "$oldClassName/$oldMethodName $oldMethodDescriptor"
+      require(!(methods.containsKey(oldEntry) && newMethodName != methods[oldEntry])) {
+        ("Duplicate method mapping: " + oldEntry + " ->" + newMethodName
+            + " but already mapped to " + methods[oldEntry] + " in line=" + line)
+      }
+
+      methods[oldEntry] = newMethodName
+    } else {
+      throw IllegalArgumentException("Unable to parse srg file, unrecognized mapping type in line=$line")
+    }
+  }
+
+}

--- a/buildSrc/src/main/kotlin/com/github/jikoo/openinv/specialsource/ReflectionPreprocessor.kt
+++ b/buildSrc/src/main/kotlin/com/github/jikoo/openinv/specialsource/ReflectionPreprocessor.kt
@@ -1,0 +1,105 @@
+package com.github.jikoo.openinv.specialsource
+
+import net.md_5.specialsource.NodeType
+import net.md_5.specialsource.RemapperProcessor
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type
+import org.objectweb.asm.tree.AbstractInsnNode
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.LdcInsnNode
+import org.objectweb.asm.tree.MethodInsnNode
+
+open class ReflectionPreprocessor(
+  private val jarMapping: ReflectionJarMapping
+) : RemapperProcessor(null, jarMapping, null) {
+
+  override fun process(classReader: ClassReader): ByteArray {
+    val classNode = ClassNode()
+    classReader.accept(classNode, 0)
+
+    for (methodNode in classNode.methods) {
+      var insn = methodNode.instructions.first
+      while (insn != null) {
+        when (insn.opcode) {
+          Opcodes.INVOKEVIRTUAL -> this.remapGetDeclaredField(insn)
+          Opcodes.INVOKESTATIC -> this.remapClassForName(insn)
+        }
+        insn = insn.next
+      }
+    }
+
+    val classWriter = ClassWriter(0)
+    classNode.accept(classWriter)
+    return classWriter.toByteArray()
+  }
+
+  open fun remapGetDeclaredField(insn: AbstractInsnNode) {
+    val mi = insn as MethodInsnNode
+
+    if (mi.owner != "java/lang/Class" || mi.name != "getDeclaredField" || mi.desc != "(Ljava/lang/String;)Ljava/lang/reflect/Field;") {
+      return
+    }
+
+    this.logR("Found getDeclaredField!")
+    if (insn.previous == null || insn.previous.opcode != Opcodes.LDC) {
+      this.logR("- not constant field; skipping, prev=" + insn.getPrevious())
+      return
+    }
+    val ldcField = insn.getPrevious() as LdcInsnNode
+    if (ldcField.cst !is String) {
+      this.logR("- not field string; skipping: ${ldcField.cst}")
+      return
+    }
+    val fieldName = ldcField.cst as String
+    if (ldcField.previous == null || ldcField.previous.opcode != Opcodes.LDC) {
+      this.logR("- not constant class; skipping: field=$fieldName")
+      return
+    }
+    val ldcClass = ldcField.previous as LdcInsnNode
+    if (ldcClass.cst !is Type) {
+      this.logR("- not class type; skipping: field=${ldcClass.cst}, class=${ldcClass.cst}")
+      return
+    }
+
+    val className = (ldcClass.cst as Type).internalName
+    val newName = jarMapping.tryClimb(jarMapping.reflectableFields, NodeType.FIELD, className, fieldName, null, 0)
+    this.logR("Remapping $className/$fieldName -> $newName")
+    if (newName != null) {
+      ldcField.cst = newName
+    }
+  }
+
+  open fun remapClassForName(insn: AbstractInsnNode) {
+    val mi = insn as MethodInsnNode
+
+    if (mi.owner != "java/lang/Class" || mi.name != "forName" || mi.desc != "(Ljava/lang/String;)Ljava/lang/Class;") {
+      return
+    }
+    this.logR("Found Class forName!")
+    if (insn.getPrevious() == null || insn.getPrevious().opcode != Opcodes.LDC) {
+      this.logR("- not constant field; skipping, prev=${insn.previous}")
+      return
+    }
+    val ldcClassName = insn.getPrevious() as LdcInsnNode
+    if (ldcClassName.cst !is String) {
+      this.logR("- not field string; skipping: " + ldcClassName.cst)
+      return
+    }
+
+    val className = ldcClassName.cst as String
+    val newName = jarMapping.classes[className.replace('.', '/')]
+    this.logR("Remapping $className -> $newName")
+    if (newName != null) {
+      ldcClassName.cst = newName.replace('/', '.')
+    }
+  }
+
+  protected fun logR(message: String) {
+    if (this.debug) {
+      println("[ReflectionRemapper] $message")
+    }
+  }
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,14 +5,14 @@ planarwrappers = "3.3.0"
 annotations = "26.0.2"
 paperweight = "2.0.0-beta.14"
 shadow = "8.3.6"
-folia = "v0.0.3"
+folia-scheduler-wrapper = "v0.0.3"
 
 [libraries]
 spigotapi = { module = "org.spigotmc:spigot-api", version.ref = "spigotapi" }
 specialsource = { module = "net.md-5:SpecialSource", version.ref = "specialsource" }
 planarwrappers = { module = "com.github.jikoo:planarwrappers", version.ref = "planarwrappers" }
 annotations = { module = "org.jetbrains:annotations", version.ref = "annotations" }
-folia = { module = "com.github.NahuLD.folia-scheduler-wrapper:folia-scheduler-wrapper", version.ref = "folia" }
+folia-scheduler-wrapper = { module = "com.github.NahuLD.folia-scheduler-wrapper:folia-scheduler-wrapper", version.ref = "folia-scheduler-wrapper" }
 
 [plugins]
 paperweight = { id = "io.papermc.paperweight.userdev", version.ref = "paperweight" }

--- a/internal/spigot/src/main/java/com/lishid/openinv/internal/reobf/container/AnySilentContainer.java
+++ b/internal/spigot/src/main/java/com/lishid/openinv/internal/reobf/container/AnySilentContainer.java
@@ -45,10 +45,10 @@ public class AnySilentContainer extends AnySilentContainerBase {
     this.lang = lang;
     try {
       try {
-        this.serverPlayerGameModeGameType = ServerPlayerGameMode.class.getDeclaredField("b");
+        this.serverPlayerGameModeGameType = ServerPlayerGameMode.class.getDeclaredField("gameModeForPlayer");
         this.serverPlayerGameModeGameType.setAccessible(true);
       } catch (NoSuchFieldException e) {
-        logger.warning("The mapping of ServerPlayerGameMode#gameModeForPlayer has changed!");
+        logger.warning("The field ServerPlayerGameMode#gameModeForPlayer is no longer present!");
         logger.warning("Please report this at https://github.com/Jikoo/OpenInv/issues");
         logger.warning("Attempting to fall through using reflection. Please verify that SilentContainer does not fail.");
         // N.B. gameModeForPlayer is (for now) declared before previousGameModeForPlayer so silent shouldn't break.

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
   implementation(project(":openinvadapterpaper1_21_1"))
   implementation(project(":openinvadapterspigot", configuration = SpigotReobf.ARTIFACT_CONFIG))
   implementation(libs.planarwrappers)
-  implementation(libs.folia)
+  implementation(libs.folia.scheduler.wrapper)
 }
 
 tasks.processResources {
@@ -29,10 +29,11 @@ tasks.jar {
 }
 
 tasks.shadowJar {
-  relocate("me.nahu.scheduler.wrapper", "com.lishid.openinv.internal.folia.scheduler")
+  relocate("me.nahu.scheduler.wrapper", "com.github.jikoo.openinv.lib.nahu.scheduler-wrapper")
+  relocate("com.github.jikoo.planarwrappers", "com.github.jikoo.openinv.lib.planarwrappers")
   minimize {
     exclude(":openinv**")
-    exclude(dependency("com.github.NahuLD.folia-scheduler-wrapper:folia-scheduler-wrapper:.*"))
+    exclude(dependency(libs.folia.scheduler.wrapper.get()))
   }
 }
 


### PR DESCRIPTION
Currently this is a minimal hack around SS not providing a way to use a preprocessor via cli and not being able to remap reflective field access due to field type being included in Proguard mappings.

I think a cleaner solution might be to write a RemapperProcessor that consumes a separate set of mappings. The ReflectionJarMapping class should also probably be in Java so that it can be copied and pasted to update. Will need to include a header with SS's copyright if that's the case.
Ideally a custom RemapperProcessor will also not require an InheritanceMap, because it prints out every single class without a superclass with no way to suppress it. If not, I'm sure there's another workaround.