### PR TITLE
The api build wasn't publishing a .jar file

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -8,6 +8,7 @@ publishing {
     create<MavenPublication>("jitpack") {
       groupId = "com.github.Jikoo.OpenInv"
       artifactId = "openinvapi"
+      from(components["java"])
     }
   }
 }


### PR DESCRIPTION
I was trying to use the OpenInv api in my maven project. But I kept getting errors that the artifact couldn't be downloaded. I looked at the actual repo link and found out it only contained the pom file and no jar file. 

I tried building the project and publishing it on my local maven repo. Same thing, no jar file. So I searched around a bit and added the line from(components["java"]) in the build.gradle.kts of api.

When I tried building it again, it worked, the jar was correctly put in my local repo. So here's that fix.

