### PR TITLE
Allow addons to enable SilentContainer without permission

### DIFF
--- a/common/src/main/java/com/lishid/openinv/util/Permissions.java
+++ b/common/src/main/java/com/lishid/openinv/util/Permissions.java
@@ -49,7 +49,9 @@ public enum Permissions {
   SPECTATE_CLICK("spectate.click"),
 
   CONTAINER_ANY("container.any"),
+  CONTAINER_ANY_USE("container.any.use"),
   CONTAINER_SILENT("container.silent"),
+  CONTAINER_SILENT_USE("container.silent.use"),
   SEARCH_INVENTORY("search.inventory"),
   SEARCH_CONTAINER("search.container");
 
@@ -63,4 +65,9 @@ public enum Permissions {
     return permissible.hasPermission(permission);
   }
 
+  public boolean hasPermission(@NotNull Permissible permissible, @NotNull Permissions parent) {
+    if (permissible.hasPermission(permission)) return true;
+    if (permissible.isPermissionSet(permission) && !permissible.hasPermission(permission)) return false;
+    return permissible.hasPermission(parent.permission);
+  }
 }

--- a/plugin/src/main/java/com/lishid/openinv/listener/ContainerListener.java
+++ b/plugin/src/main/java/com/lishid/openinv/listener/ContainerListener.java
@@ -72,14 +72,14 @@ public class ContainerListener implements Listener {
 
     Player player = event.getPlayer();
     UUID playerId = player.getUniqueId();
-    boolean any = Permissions.CONTAINER_ANY.hasPermission(player) && PlayerToggles.any().is(playerId);
+    boolean any = Permissions.CONTAINER_ANY_USE.hasPermission(player, Permissions.CONTAINER_ANY) && PlayerToggles.any().is(playerId);
     boolean needsAny = accessor.getAnySilentContainer().isAnyContainerNeeded(event.getClickedBlock());
 
     if (!any && needsAny) {
       return;
     }
 
-    boolean silent = Permissions.CONTAINER_SILENT.hasPermission(player) && PlayerToggles.silent().is(playerId);
+    boolean silent = Permissions.CONTAINER_SILENT_USE.hasPermission(player, Permissions.CONTAINER_SILENT) && PlayerToggles.silent().is(playerId);
 
     // If anycontainer or silentcontainer is active
     if (any || silent) {

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -76,8 +76,16 @@ permissions:
       # Container features
       openinv.container:
         children:
-          openinv.container.any: true
-          openinv.container.silent: true
+          openinv.container.any:
+            children:
+              openinv.container.any.use: true
+          openinv.container.any.use:
+            default: false
+          openinv.container.silent:
+            children:
+              openinv.container.silent.use: true
+          openinv.container.silent.use:
+            default: false
       # Search functionality
       openinv.search:
         children:


### PR DESCRIPTION
This fix allows third-party plugins to temporarily enable a user to open containers silently using OpenInv API. 
The permission check is unnecessary because silent mode is disabled by default, and enabling it via command requires a permission.

An example:
I want staff members to be able to open containers silently **only** while in vanish, so via the API I add the staff member to the list as soon as they enter vanish.
Previously, with the permission check in place, the shulker box would bug out: the animation would start and, once closed, it would remain open.
Now, with this change, the staff member can open the shulker silently while in vanish and, once they exit vanish mode, they will no longer be able to do so.
