### PR TITLE
fix missed itemStack.copy() call in sendAllDataToRemote

### DIFF
--- a/internal/paper26_1/src/main/java/com/lishid/openinv/internal/paper26_1/container/menu/OpenSyncMenu.java
+++ b/internal/paper26_1/src/main/java/com/lishid/openinv/internal/paper26_1/container/menu/OpenSyncMenu.java
@@ -89,7 +89,7 @@ public abstract class OpenSyncMenu<T extends Container & ISpecialInventory & Int
     for (int index = 0; index < slots.size(); ++index) {
       Slot slot = slots.get(index);
       ItemStack itemStack = slot instanceof SlotPlaceholder placeholder ? placeholder.getOrDefault() : slot.getItem();
-      contentsCopy.add(itemStack);
+      contentsCopy.add(itemStack.copy());
       this.remoteSlots.get(index).force(itemStack);
     }
 

--- a/internal/spigot/src/main/java/com/github/jikoo/openinv/internal/spigot26_1/container/menu/OpenSyncMenu.java
+++ b/internal/spigot/src/main/java/com/github/jikoo/openinv/internal/spigot26_1/container/menu/OpenSyncMenu.java
@@ -96,7 +96,7 @@ public abstract class OpenSyncMenu<T extends Container & ISpecialInventory & Int
     for (int index = 0; index < slots.size(); ++index) {
       Slot slot = slots.get(index);
       ItemStack itemStack = slot instanceof SlotPlaceholder placeholder ? placeholder.getOrDefault() : slot.getItem();
-      contentsCopy.add(itemStack);
+      contentsCopy.add(itemStack.copy());
       this.remoteSlots.get(index).force(itemStack);
     }
 


### PR DESCRIPTION
the current sendAllDataToRemote in the OpenSyncMenu is missing the .copy() call of the ites being sent which causes behaviour inconsistencies. Servers that have plugins that modify items on a packet level expect all items to be pre-cloned. This was missed when creating the copies of the method on AbstractContainer
