### PR TITLE
Fix search commands reporting only the first matching player

### DIFF
--- a/plugin/src/main/java/com/lishid/openinv/command/SearchInvCommand.java
+++ b/plugin/src/main/java/com/lishid/openinv/command/SearchInvCommand.java
@@ -85,7 +85,6 @@ public class SearchInvCommand implements TabExecutor {
       Inventory inventory = searchInv ? player.getInventory() : player.getEnderChest();
       if (findMatch(inventory, material, count)) {
         players.append(player.getName()).append(", ");
-        break;
       }
     }
 


### PR DESCRIPTION
- Resolves https://github.com/Jikoo/OpenInv/issues/413
- Regression introduced by: https://github.com/Jikoo/OpenInv/pull/311

Before the regression, `SearchInvCommand` used two nested loops: an outer loop over online players and an inner loop over the inventory contents. The `break` lived in the **inner** loop, ending the per-item count-up once the requested threshold was reached.

That commit extracted the inner loop into `SearchHelper.findMatch(...)` but left the `break` behind. It now sits directly inside the **outer** `for (Player player : ...)` loop, so the entire player scan terminates at the first match.

I could be wrong about the intentionality of this `break` statement; however, in my eyes, this looks correct!