### PR TITLE
Clean up new errorprone warnings

### DIFF
--- a/internal/paper26_2/src/main/java/com/lishid/openinv/internal/paper26_2/container/menu/OpenChestMenu.java
+++ b/internal/paper26_2/src/main/java/com/lishid/openinv/internal/paper26_2/container/menu/OpenChestMenu.java
@@ -163,17 +163,17 @@ public abstract class OpenChestMenu<T extends Container & ISpecialInventory & In
 
   private int getTopSize(ServerPlayer viewer) {
     MenuType<?> menuType = getType();
-    if (menuType == MenuType.GENERIC_9x1) {
+    if (MenuType.GENERIC_9x1.equals(menuType)) {
       return 9;
-    } else if (menuType == MenuType.GENERIC_9x2) {
+    } else if (MenuType.GENERIC_9x2.equals(menuType)) {
       return 18;
-    } else if (menuType == MenuType.GENERIC_9x3) {
+    } else if (MenuType.GENERIC_9x3.equals(menuType)) {
       return 27;
-    } else if (menuType == MenuType.GENERIC_9x4) {
+    } else if (MenuType.GENERIC_9x4.equals(menuType)) {
       return 36;
-    } else if (menuType == MenuType.GENERIC_9x5) {
+    } else if (MenuType.GENERIC_9x5.equals(menuType)) {
       return 45;
-    } else if (menuType == MenuType.GENERIC_9x6) {
+    } else if (MenuType.GENERIC_9x6.equals(menuType)) {
       return 54;
     }
     // This is a bit gross, but allows us a safe fallthrough.

--- a/internal/paper26_2/src/main/java/com/lishid/openinv/internal/paper26_2/container/slot/ContentOffHand.java
+++ b/internal/paper26_2/src/main/java/com/lishid/openinv/internal/paper26_2/container/slot/ContentOffHand.java
@@ -10,6 +10,8 @@ import net.minecraft.world.inventory.Slot;
 import org.bukkit.event.inventory.InventoryType;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 /**
  * A slot for equipment that updates held items if necessary.
  */
@@ -37,7 +39,7 @@ public class ContentOffHand extends ContentEquipment {
     return new SlotEquipment(container, slot, x, y) {
       @Override
       public void setChanged() {
-        if (OpenPlayer.isConnected(holder.connection) && holder.containerMenu != holder.inventoryMenu) {
+        if (OpenPlayer.isConnected(holder.connection) && !Objects.equals(holder.containerMenu, holder.inventoryMenu)) {
           holder.connection.send(
               new ClientboundContainerSetSlotPacket(
                   holder.inventoryMenu.containerId,

--- a/internal/spigot26_2/src/main/java/com/github/jikoo/openinv/internal/spigot26_2/container/menu/OpenChestMenu.java
+++ b/internal/spigot26_2/src/main/java/com/github/jikoo/openinv/internal/spigot26_2/container/menu/OpenChestMenu.java
@@ -164,17 +164,17 @@ public abstract class OpenChestMenu<T extends Container & ISpecialInventory & In
 
   private int getTopSize(ServerPlayer viewer) {
     MenuType<?> menuType = getType();
-    if (menuType == MenuType.GENERIC_9x1) {
+    if (MenuType.GENERIC_9x1.equals(menuType)) {
       return 9;
-    } else if (menuType == MenuType.GENERIC_9x2) {
+    } else if (MenuType.GENERIC_9x2.equals(menuType)) {
       return 18;
-    } else if (menuType == MenuType.GENERIC_9x3) {
+    } else if (MenuType.GENERIC_9x3.equals(menuType)) {
       return 27;
-    } else if (menuType == MenuType.GENERIC_9x4) {
+    } else if (MenuType.GENERIC_9x4.equals(menuType)) {
       return 36;
-    } else if (menuType == MenuType.GENERIC_9x5) {
+    } else if (MenuType.GENERIC_9x5.equals(menuType)) {
       return 45;
-    } else if (menuType == MenuType.GENERIC_9x6) {
+    } else if (MenuType.GENERIC_9x6.equals(menuType)) {
       return 54;
     }
     // This is a bit gross, but allows us a safe fallthrough.

--- a/internal/spigot26_2/src/main/java/com/github/jikoo/openinv/internal/spigot26_2/container/slot/ContentOffHand.java
+++ b/internal/spigot26_2/src/main/java/com/github/jikoo/openinv/internal/spigot26_2/container/slot/ContentOffHand.java
@@ -34,7 +34,7 @@ public class ContentOffHand extends ContentEquipment {
     return new SlotEquipment(container, slot, x, y) {
       @Override
       public void setChanged() {
-        if (OpenPlayer.isConnected(holder.connection) && holder.containerMenu != holder.inventoryMenu) {
+        if (OpenPlayer.isConnected(holder.connection) && !holder.containerMenu.equals(holder.inventoryMenu)) {
           holder.connection.send(
               new ClientboundContainerSetSlotPacket(
                   holder.inventoryMenu.containerId,

--- a/internal/spigot26_2/src/main/java/com/github/jikoo/openinv/internal/spigot26_2/container/slot/ContentOffHand.java
+++ b/internal/spigot26_2/src/main/java/com/github/jikoo/openinv/internal/spigot26_2/container/slot/ContentOffHand.java
@@ -10,6 +10,8 @@ import net.minecraft.world.inventory.Slot;
 import org.bukkit.event.inventory.InventoryType;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 public class ContentOffHand extends ContentEquipment {
 
   private ServerPlayer holder;
@@ -34,7 +36,7 @@ public class ContentOffHand extends ContentEquipment {
     return new SlotEquipment(container, slot, x, y) {
       @Override
       public void setChanged() {
-        if (OpenPlayer.isConnected(holder.connection) && !holder.containerMenu.equals(holder.inventoryMenu)) {
+        if (OpenPlayer.isConnected(holder.connection) && !Objects.equals(holder.containerMenu, holder.inventoryMenu)) {
           holder.connection.send(
               new ClientboundContainerSetSlotPacket(
                   holder.inventoryMenu.containerId,

--- a/plugin/src/main/java/com/lishid/openinv/util/InventoryManager.java
+++ b/plugin/src/main/java/com/lishid/openinv/util/InventoryManager.java
@@ -133,6 +133,7 @@ public class InventoryManager implements Listener {
 
   @Keep
   @EventHandler
+  @SuppressWarnings("ReferenceEquality") // We do really want to check that we have the same ref here.
   private void onInventoryClose(@NotNull InventoryCloseEvent event) {
     ISpecialInventory inventory = InventoryAccess.getInventory(event.getInventory());
 


### PR DESCRIPTION
* MenuType is no longer an enum
* Offhand is fine with equality check
* InventoryManager really does intend to check if the references match